### PR TITLE
1.1.1 - Bugfixes, feature enhancements.

### DIFF
--- a/app/SymfonyRequirements.php
+++ b/app/SymfonyRequirements.php
@@ -530,11 +530,22 @@ class SymfonyRequirements extends RequirementCollection
 
         /* optional recommendations follow */
 
-        $this->addRecommendation(
-            file_get_contents(__FILE__) === file_get_contents(__DIR__.'/../vendor/sensio/distribution-bundle/Sensio/Bundle/DistributionBundle/Resources/skeleton/app/SymfonyRequirements.php'),
-            'Requirements file should be up-to-date',
-            'Your requirements file is outdated. Run composer install and re-check your configuration.'
-        );
+        if (file_exists(__DIR__.'/../vendor/composer')) {
+            require_once __DIR__.'/../vendor/autoload.php';
+
+            try {
+                $r = new \ReflectionClass('Sensio\Bundle\DistributionBundle\SensioDistributionBundle');
+
+                $contents = file_get_contents(dirname($r->getFileName()).'/Resources/skeleton/app/SymfonyRequirements.php');
+            } catch (\ReflectionException $e) {
+                $contents = '';
+            }
+            $this->addRecommendation(
+                file_get_contents(__FILE__) === $contents,
+                'Requirements file should be up-to-date',
+                'Your requirements file is outdated. Run composer install and re-check your configuration.'
+            );
+        }
 
         $this->addRecommendation(
             version_compare($installedPhpVersion, '5.3.4', '>='),
@@ -614,15 +625,15 @@ class SymfonyRequirements extends RequirementCollection
             'Install and enable the <strong>intl</strong> extension (used for validators).'
         );
 
-        if (class_exists('Collator')) {
+        if (extension_loaded('intl')) {
+            // in some WAMP server installations, new Collator() returns null
             $this->addRecommendation(
                 null !== new Collator('fr_FR'),
                 'intl extension should be correctly configured',
                 'The intl extension does not behave properly. This problem is typical on PHP 5.3.X x64 WIN builds.'
             );
-        }
 
-        if (class_exists('Locale')) {
+            // check for compatible ICU versions (only done when you have the intl extension)
             if (defined('INTL_ICU_VERSION')) {
                 $version = INTL_ICU_VERSION;
             } else {
@@ -640,6 +651,14 @@ class SymfonyRequirements extends RequirementCollection
                 version_compare($version, '4.0', '>='),
                 'intl ICU version should be at least 4+',
                 'Upgrade your <strong>intl</strong> extension with a newer ICU version (4+).'
+            );
+
+            $this->addPhpIniRecommendation(
+                'intl.error_level',
+                create_function('$cfgValue', 'return (int) $cfgValue === 0;'),
+                true,
+                'intl.error_level should be 0 in php.ini',
+                'Set "<strong>intl.error_level</strong>" to "<strong>0</strong>" in php.ini<a href="#phpini">*</a> to inhibit the messages when an error occurs in ICU functions.'
             );
         }
 

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -14,7 +14,7 @@
     bootstrap                   = "bootstrap.php.cache" >
 
     <testsuites>
-        <testsuite name="Project Test Suite">
+        <testsuite name="ODR Test Suite">
             <directory>../src/*/*Bundle/Tests</directory>
             <directory>../src/*/Bundle/*Bundle/Tests</directory>
         </testsuite>

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "dterranova/crypto-bundle": "dev-master",
         "knplabs/knp-markdown-bundle": "~1.3",
         "symfony/filesystem": "2.3.*",
-        "ddeboer/data-import": "@stable"
+        "ddeboer/data-import": "@stable",
+        "phpunit/phpunit": "^4.8"
     },
     "scripts": {
         "post-install-cmd": [

--- a/src/ODR/AdminBundle/Controller/CSVExportController.php
+++ b/src/ODR/AdminBundle/Controller/CSVExportController.php
@@ -786,7 +786,7 @@ print_r($line);
 
                 $query =
                    'INSERT INTO odr_tracked_csv_export (random_key, tracked_job_id)
-                    SELECT * FROM (SELECT :random_key, :tj_id) AS tmp
+                    SELECT * FROM (SELECT :random_key AS random_key, :tj_id AS tj_id) AS tmp
                     WHERE NOT EXISTS (
                         SELECT random_key FROM odr_tracked_csv_export WHERE random_key = :random_key AND tracked_job_id = :tj_id
                     ) LIMIT 1;';
@@ -868,7 +868,7 @@ print_r($line);
                 // TODO - CURRENTLY WORKS, BUT MIGHT WANT TO LOOK INTO AN OFFICIAL MUTEX...
                 $query =
                    'INSERT INTO odr_tracked_csv_export (random_key, tracked_job_id, finalize)
-                    SELECT * FROM (SELECT :random_key_hash, :tj_id, :finalize) AS tmp
+                    SELECT * FROM (SELECT :random_key_hash AS random_key_hash, :tj_id AS tj_id, :finalize AS final_flag) AS tmp
                     WHERE NOT EXISTS (
                         SELECT random_key FROM odr_tracked_csv_export WHERE random_key = :random_key_hash AND tracked_job_id = :tj_id AND finalize = :finalize
                     ) LIMIT 1;';

--- a/src/ODR/AdminBundle/Controller/CSVExportController.php
+++ b/src/ODR/AdminBundle/Controller/CSVExportController.php
@@ -603,6 +603,7 @@ if ($debug)
 
             // ----------------------------------
             // Need to grab external id for this datarecord
+/*
             $query = $em->createQuery(
                'SELECT dr.external_id AS external_id
                 FROM ODRAdminBundle:DataRecord AS dr
@@ -611,7 +612,9 @@ if ($debug)
             $result = $query->getArrayResult();
 //print_r($result);
             $external_id = $result[0]['external_id'];
-
+*/
+            $datarecord = $em->getRepository('ODRAdminBundle:DataRecord')->find($datarecord_id);
+            $external_id = $datarecord->getExternalId();
 
             // ----------------------------------
             // Grab data for each of the datafields selected for export

--- a/src/ODR/AdminBundle/Controller/CSVImportController.php
+++ b/src/ODR/AdminBundle/Controller/CSVImportController.php
@@ -2128,7 +2128,7 @@ print_r($new_mapping);
                                 // define and execute a query to manually create the absolute minimum required for a RadioOption entity...
                                 $query = 
                                    'INSERT INTO odr_radio_options (option_name, data_fields_id)
-                                    SELECT * FROM (SELECT :name, :df_id) AS tmp
+                                    SELECT * FROM (SELECT :name AS option_name, :df_id AS df_id) AS tmp
                                     WHERE NOT EXISTS (
                                         SELECT option_name FROM odr_radio_options WHERE option_name = :name AND data_fields_id = :df_id AND deletedAt IS NULL
                                     ) LIMIT 1;';

--- a/src/ODR/AdminBundle/Controller/CSVImportController.php
+++ b/src/ODR/AdminBundle/Controller/CSVImportController.php
@@ -1253,9 +1253,9 @@ class CSVImportController extends ODRCustomController
                 if ( isset($unique_columns[$column_num]) && $datafield_id !== 'new' ) {
                     // Skip if this column is mapped to the external id/name datafield for this datatype
                     $external_id_field = $datatype->getExternalIdField();
-                    $name_field = $datatype->getNameField();
+//                    $name_field = $datatype->getNameField();
 
-                    if ( ($external_id_field !== null && $external_id_field->getId() == $datafield_id) || ($name_field !== null && $name_field->getId() == $datafield_id) ) {
+                    if ( ($external_id_field !== null && $external_id_field->getId() == $datafield_id) /*|| ($name_field !== null && $name_field->getId() == $datafield_id)*/ ) {
                         /* don't check whether the value collides with an existing value for either of these datafields...if it did, the importer would be unable to update existing datarecords */
                     }
                     else {
@@ -1913,12 +1913,13 @@ print_r($new_mapping);
             $status = '';
             $datarecord = null;
             $external_id_field = $datatype->getExternalIdField();
-            $name_field = $datatype->getNameField();
+//            $name_field = $datatype->getNameField();
 
             $source = '';
             $value = '';
             $typeclass = '';
             $datafield_id = '';
+/*
             // Try to first locate the name field value...
             if ($name_field !== null) {
                 $source = 'Name datafield';
@@ -1929,7 +1930,7 @@ print_r($new_mapping);
                         $value = $line[$column_num];
                 }
             }
-
+*/
             // Try to locate the external id field value...purposefully overwrite the value from the name field because...
             if ($external_id_field !== null) {
                 $source = 'External ID datafield';
@@ -2224,5 +2225,3 @@ print_r($new_mapping);
     }
 
 }
-
-?>

--- a/src/ODR/AdminBundle/Controller/DisplaytemplateController.php
+++ b/src/ODR/AdminBundle/Controller/DisplaytemplateController.php
@@ -2530,7 +2530,7 @@ print '</pre>';
                 if ($render_plugin->getPluginType() <= 2 && $datatype != null) {
                     // Update the datatype object
                     $datatype->setRenderPlugin($render_plugin);
-                    $datatype->setDisplayType(0);   // if changing to use a render plugin, revert datatype back to accordion layout
+//                    $datatype->setDisplayType(0);   // if changing to use a render plugin, revert datatype back to accordion layout
                     $datatype->setUpdatedBy($user);
                     $em->persist($datatype);
                 }

--- a/src/ODR/AdminBundle/Controller/DisplaytemplateController.php
+++ b/src/ODR/AdminBundle/Controller/DisplaytemplateController.php
@@ -3330,7 +3330,7 @@ print_r($errors);
                             $top_level_datatype_id = $datafield->getDataType()->getId();
                             $datatree_array = parent::getDatatreeArray($em);
 
-                            while ($datatree_array['descendant_of'][$top_level_datatype_id] !== '')
+                            while ( isset($datatree_array['descendant_of'][$top_level_datatype_id]) && $datatree_array['descendant_of'][$top_level_datatype_id] !== '')
                                 $top_level_datatype_id = $datatree_array['descendant_of'][$top_level_datatype_id];
 
 

--- a/src/ODR/AdminBundle/Controller/JobController.php
+++ b/src/ODR/AdminBundle/Controller/JobController.php
@@ -243,6 +243,9 @@ class JobController extends ODRCustomController
                     $datatype_id = $tmp[1];
 
                     $datatype = $repo_datatype->find($datatype_id);
+                    if ($datatype == null)
+                        continue;
+
                     $job['revision'] = $datatype->getRevision();
                     $job['description'] = 'Recache of Datatype "'.$datatype->getShortName().'"';
                 }
@@ -251,6 +254,9 @@ class JobController extends ODRCustomController
                     $datatype_id = $tmp[1];
 
                     $datatype = $repo_datatype->find($datatype_id);
+                    if ($datatype == null)
+                        continue;
+
                     $job['description'] = 'CSV Export from Datatype "'.$datatype->getShortName().'"';
 //                    $job['datatype_id'] = $datatype_id;
                     $job['user_id'] = $tracked_job->getCreatedBy()->getId();
@@ -260,6 +266,9 @@ class JobController extends ODRCustomController
                     $datatype_id = $tmp[1];
 
                     $datatype = $repo_datatype->find($datatype_id);
+                    if ($datatype == null)
+                        continue;
+
                     $job['description'] = 'Validating csv import data for DataType "'.$datatype->getShortName().'"';
                 }
                 else if ($job_type == 'csv_import') {
@@ -267,6 +276,9 @@ class JobController extends ODRCustomController
                     $datatype_id = $tmp[1];
 
                     $datatype = $repo_datatype->find($datatype_id);
+                    if ($datatype == null)
+                        continue;
+
                     $job['description'] = 'Importing data into DataType "'.$datatype->getShortName().'"';
                 }
                 else if ($job_type == 'mass_edit') {
@@ -274,6 +286,9 @@ class JobController extends ODRCustomController
                     $datatype_id = $tmp[1];
 
                     $datatype = $repo_datatype->find($datatype_id);
+                    if ($datatype == null)
+                        continue;
+
                     $job['description'] = 'Mass Edit of DataType "'.$datatype->getShortName().'"';
                 }
                 else if ($job_type == 'migrate') {
@@ -288,9 +303,9 @@ class JobController extends ODRCustomController
 
                     $datafield = $repo_datafield->find($datafield_id);
                     if ($datafield == null)
-                        $job['description'] = 'Migration of currently deleted DataField '.$datafield_id.' from "'.$old_fieldtype.'" to "'.$new_fieldtype.'"';
-                    else
-                        $job['description'] = 'Migration of DataField "'.$datafield->getFieldName().'" from "'.$old_fieldtype.'" to "'.$new_fieldtype.'"';
+                        continue;
+
+                    $job['description'] = 'Migration of DataField "'.$datafield->getFieldName().'" from "'.$old_fieldtype.'" to "'.$new_fieldtype.'"';
                 }
 
 

--- a/src/ODR/AdminBundle/Controller/ODRCustomController.php
+++ b/src/ODR/AdminBundle/Controller/ODRCustomController.php
@@ -827,10 +827,12 @@ print "\n\n";
 //$save_permissions = false;
             $session = $request->getSession();
             if ( !$save_permissions || !$session->has('permissions') ) {
-                // Permissions not set, need to build an array
+                // Permissions for a user other than the currently logged-in one requested, or permissions not set...need to build an array
                 $em = $this->getDoctrine()->getManager();
-                $repo_user_permissions = $em->getRepository('ODRAdminBundle:UserPermissions');
+                $user = $em->getRepository('ODROpenRepositoryUserBundle:User')->find($user_id);
+                $is_admin = $user->hasRole('ROLE_SUPER_ADMIN');
 
+                // Load all permissions for this user from the database
                 $query = $em->createQuery(
                    'SELECT dt.id AS dt_id, up.can_view_type, up.can_edit_record, up.can_add_record, up.can_delete_record, up.can_design_type, up.is_type_admin
                     FROM ODRAdminBundle:DataType AS dt
@@ -851,11 +853,11 @@ print "\n\n";
                     $all_permissions[$datatype_id] = array();
                     $save = false;
 
-                    if ($result['can_view_type'] == 1) {
+                    if ( $is_admin || $result['can_view_type'] == 1 ) {
                         $all_permissions[$datatype_id]['view'] = 1;
                         $save = true; 
                     }
-                    if ($result['can_edit_record'] == 1) {
+                    if ( $is_admin || $result['can_edit_record'] == 1 ) {
                         $all_permissions[$datatype_id]['edit'] = 1;
                         $save = true;
 
@@ -867,19 +869,19 @@ print "\n\n";
                                 $all_permissions[$dt_id]['child_edit'] = 1;
                         }
                     }
-                    if ($result['can_add_record'] == 1) {
+                    if ( $is_admin || $result['can_add_record'] == 1 ) {
                         $all_permissions[$datatype_id]['add'] = 1;
                         $save = true; 
                     }
-                    if ($result['can_delete_record'] == 1) {
+                    if ( $is_admin || $result['can_delete_record'] == 1 ) {
                         $all_permissions[$datatype_id]['delete'] = 1;
                         $save = true; 
                     }
-                    if ($result['can_design_type'] == 1) {
+                    if ( $is_admin || $result['can_design_type'] == 1 ) {
                         $all_permissions[$datatype_id]['design'] = 1;
                         $save = true; 
                     }
-                    if ($result['is_type_admin'] == 1) {
+                    if ( $is_admin || $result['is_type_admin'] == 1 ) {
                         $all_permissions[$datatype_id]['admin'] = 1;
                         $save = true; 
                     }

--- a/src/ODR/AdminBundle/Controller/ODRCustomController.php
+++ b/src/ODR/AdminBundle/Controller/ODRCustomController.php
@@ -1662,7 +1662,7 @@ $save_permissions = false;
         if ($drf == null) {
             $query =
                'INSERT INTO odr_data_record_fields (data_record_id, data_field_id)
-                SELECT * FROM (SELECT :datarecord, :datafield) AS tmp
+                SELECT * FROM (SELECT :datarecord AS dr_id, :datafield AS df_id) AS tmp
                 WHERE NOT EXISTS (
                     SELECT id FROM odr_data_record_fields WHERE data_record_id = :datarecord AND data_field_id = :datafield AND deletedAt IS NULL
                 ) LIMIT 1;';
@@ -2925,7 +2925,7 @@ if ($debug)
             // Create an ImageSize entity for the original image
             $query =
                'INSERT INTO odr_image_sizes (data_fields_id, size_constraint)
-                SELECT * FROM (SELECT :datafield, :size_constraint) AS tmp
+                SELECT * FROM (SELECT :datafield AS df_id, :size_constraint AS size_constraint) AS tmp
                 WHERE NOT EXISTS (
                     SELECT id FROM odr_image_sizes WHERE data_fields_id = :datafield AND size_constraint = :size_constraint AND deletedAt IS NULL
                 ) LIMIT 1;';
@@ -2960,7 +2960,7 @@ if ($debug)
             // Create an ImageSize entity for the thumbnail
             $query =
                'INSERT INTO odr_image_sizes (data_fields_id, size_constraint)
-                SELECT * FROM (SELECT :datafield, :size_constraint) AS tmp
+                SELECT * FROM (SELECT :datafield AS df_id, :size_constraint AS size_constraint) AS tmp
                 WHERE NOT EXISTS (
                     SELECT id FROM odr_image_sizes WHERE data_fields_id = :datafield AND size_constraint = :size_constraint AND deletedAt IS NULL
                 ) LIMIT 1;';

--- a/src/ODR/AdminBundle/Controller/ODRUserController.php
+++ b/src/ODR/AdminBundle/Controller/ODRUserController.php
@@ -66,7 +66,7 @@ class ODRUserController extends ODRCustomController
                 }
             }
 
-            if ( count($admin_permissions) == 0 )
+            if ( !$admin_user->hasRole('ROLE_SUPER_ADMIN') && count($admin_permissions) == 0 )
                 return parent::permissionDeniedError();
             // --------------------
 
@@ -126,7 +126,7 @@ class ODRUserController extends ODRCustomController
                 }
             }
 
-            if ( count($admin_permissions) == 0 )
+            if ( !$admin_user->hasRole('ROLE_SUPER_ADMIN') && count($admin_permissions) == 0 )
                 return parent::permissionDeniedError();
             // --------------------
 
@@ -196,7 +196,7 @@ class ODRUserController extends ODRCustomController
                 }
             }
 
-            if ( count($admin_permissions) == 0 )
+            if ( !$admin_user->hasRole('ROLE_SUPER_ADMIN') && count($admin_permissions) == 0 )
                 return parent::permissionDeniedError();
             // --------------------
 
@@ -342,7 +342,7 @@ class ODRUserController extends ODRCustomController
             // Ensure user has permissions to be doing this
             $admin = $this->container->get('security.context')->getToken()->getUser();
 
-            // Bypass all this sillyness if the user is a super admin, or doing this action to his own profile for some reason
+            // Bypass all this permissions sillyness if the user is a super admin, or doing this action to his own profile for some reason
             if ( !$admin->hasRole('ROLE_SUPER_ADMIN') || $admin->getId() == $user_id ) {
 
                 // If user lacks super admin and admin roles, not allowed to do this
@@ -423,8 +423,6 @@ class ODRUserController extends ODRCustomController
             // Grab the current user
             $user = $this->container->get('security.context')->getToken()->getUser();
 
-//print_r($post);
-//return;
             // Only allow this if the user is modifying their own profile
             $post = $request->request->all();
             if ( isset($post['ODRUserProfileForm']) && $user->getId() == $post['ODRUserProfileForm']['user_id'])
@@ -462,8 +460,7 @@ class ODRUserController extends ODRCustomController
         try {
             // Need to get the user id out of the form to check permissions...
             $post = $request->request->all();
-//print_r($post);
-//return;
+
             if ( !isset($post['ODRUserProfileForm']) )
                 throw new \Exception('Invalid Form');
             $user_id = intval( $post['ODRUserProfileForm']['id'] );
@@ -478,7 +475,7 @@ class ODRUserController extends ODRCustomController
             // Ensure user has permissions to be doing this
             $admin = $this->container->get('security.context')->getToken()->getUser();
 
-            // Bypass all this sillyness if the user is a super admin, or doing this action to his own profile for some reason
+            // Bypass all this permissions sillyness if the user is a super admin, or doing this action to his own profile for some reason
             if ( !$admin->hasRole('ROLE_SUPER_ADMIN') || $admin->getId() == $user_id ) {
 
                 // If user lacks super admin and admin roles, not allowed to do this
@@ -562,12 +559,12 @@ class ODRUserController extends ODRCustomController
         $form = $this->createForm(new ODRUserProfileForm($target_user), $target_user);
         $form->bind($request, $target_user);
 
-        // TODO - check for additional errors to throw?
+        // TODO - check for additional non-password errors to throw?
 
         // If no errors...
         if ( $form->isValid() ) {
             // Save changes to the user
-            $target_user->setEmail($email);     // as of right now, form will reset the user's email/username because the field is disabled...set the email/username back to what they were
+            $target_user->setEmail($email);     // as of right now, binding the form will clear the user's email/username because that field is disabled...set the email/username back to what it was originally
             $user_manager->updateUser($target_user);
         }
         else {
@@ -611,7 +608,7 @@ class ODRUserController extends ODRCustomController
             // Ensure user has permissions to be doing this
             $admin = $this->container->get('security.context')->getToken()->getUser();
 
-            // Bypass all this sillyness if the user is a super admin, or doing this action to his own profile for some reason
+            // Bypass all this permissions sillyness if the user is a super admin, or doing this action to his own profile for some reason
             if ( !$admin->hasRole('ROLE_SUPER_ADMIN') || $admin->getId() == $user_id ) {
 
                 // If user lacks super admin and admin roles, not allowed to do this
@@ -706,7 +703,7 @@ class ODRUserController extends ODRCustomController
             // Ensure user has permissions to be doing this
             $admin = $this->container->get('security.context')->getToken()->getUser();
 
-            // Bypass all this sillyness if the user is a super admin, or doing this action to his own profile for some reason
+            // Bypass all this permissions sillyness if the user is a super admin, or doing this action to his own profile for some reason
             if ( !$admin->hasRole('ROLE_SUPER_ADMIN') || $admin->getId() == $target_user_id ) {
 
                 // If user lacks super admin and admin roles, not allowed to do this
@@ -804,7 +801,7 @@ class ODRUserController extends ODRCustomController
                 }
             }
 
-            if ( count($admin_permissions) == 0 )
+            if ( !$admin_user->hasRole('ROLE_SUPER_ADMIN') && count($admin_permissions) == 0 )
                 return parent::permissionDeniedError();
             // --------------------
 
@@ -1141,7 +1138,7 @@ class ODRUserController extends ODRCustomController
                 }
             }
 
-            if ( count($admin_permissions) == 0 )
+            if ( !$admin_user->hasRole('ROLE_SUPER_ADMIN') && count($admin_permissions) == 0 )
                 return parent::permissionDeniedError();
             // --------------------
 
@@ -1328,6 +1325,7 @@ class ODRUserController extends ODRCustomController
 
     /**
      * Updates a UserPermission object in the database.
+     * TODO - invalidate current permissions set for target user after save
      * 
      * @param User $user         The User that is getting their permissions modified.
      * @param DataType $datatype The DataType that the User's permissions are being modified for.
@@ -1489,7 +1487,7 @@ class ODRUserController extends ODRCustomController
                 }
             }
 
-            if ( count($admin_permissions) == 0 )
+            if ( !$admin_user->hasRole('ROLE_SUPER_ADMIN') && count($admin_permissions) == 0 )
                 return parent::permissionDeniedError();
             // --------------------
 
@@ -1709,9 +1707,9 @@ class ODRUserController extends ODRCustomController
 
 
     /**
-     * Updates the number of results on a page used by ShortResults
+     * Changes the number of Datarecords displayed per ShortResults page...TextResults handles its own version
      *
-     * @param integer $length  How many ShortResult datarecords to show on a page.
+     * @param integer $length  How many Datarecords to display on a page.
      * @param Request $request
      *
      * @return none
@@ -1873,6 +1871,7 @@ if ($debug)
 
     /**
      * Saves a datafield permission change for a given user.
+     * TODO - invalidate current permissions set for target user after save
      *
      * @param integer $user_id      The database id of the User being modified.
      * @param integer $datafield_id The database id of the DataField being modified.
@@ -1958,7 +1957,6 @@ if ($debug)
             $em->persist($user_field_permission);
             $em->flush();
 
-            // TODO - invalidate datafield permissions across the server?
         }
         catch (\Exception $e) {
             $return['r'] = 1;

--- a/src/ODR/AdminBundle/Controller/RecordController.php
+++ b/src/ODR/AdminBundle/Controller/RecordController.php
@@ -2028,6 +2028,7 @@ if ($debug)
         $datafield_permissions = parent::getDatafieldPermissionsArray($user->getId(), $request);
         // --------------------
 
+        $parent_datarecord = null;
         $datarecord = null;
         $datatype = null;
         $theme_element = null;
@@ -2035,9 +2036,11 @@ if ($debug)
         if ( $template_name === 'child' && $child_datatype_id !== null ) {
             $datarecord = $repo_datarecord->find($datarecord_id);
             $datatype = $repo_datatype->find($child_datatype_id);
+            $parent_datarecord = $datarecord->getParent();
         }
         else {
             $datarecord = $repo_datarecord->find($datarecord_id);
+            $parent_datarecord = $datarecord;
             $datatype = $datarecord->getDataType();
         }
 
@@ -2166,6 +2169,8 @@ if ($debug)
             $template,
             array(
                 'search_key' => $search_key,
+
+                'parent_datarecord' => $parent_datarecord,
 
                 'datatype_tree' => $datatype_tree,
                 'datarecord_tree' => $datarecord_tree,

--- a/src/ODR/AdminBundle/Controller/RecordController.php
+++ b/src/ODR/AdminBundle/Controller/RecordController.php
@@ -480,42 +480,18 @@ class RecordController extends ODRCustomController
             )->setParameters( array('datatype' => $datatype->getId()) );
             $remaining = $query->getArrayResult();
 
-            // Determine which url to redirect to
+            // Determine where to redirect since the current datareccord is now deleted
             $url = '';
-/*
-            if ($search_key == '') {
-                // Not deleting from a search result list
-                if ( count($remaining) > 0 ) {
-                    // Return the url to Get ShortResults controller to regenerate the list of datarecords for this datatype
-                    $url = $this->generateUrl('odr_shortresults_list', array('datatype_id' => $datatype->getId(), 'target' => 'record'));
-                }
-                else {
-                    // No records to display on a ShortResults list, return to list of all datatypes
-                    $url = $this->generateUrl('odr_list_types', array('section' => 'records'));
-                }
-            }
-            else {
-                // Deleting from a search result list
-                if ( count($remaining) > 0 ) {
-                    // Redirect to search list
-                    $url = $this->generateURL('odr_search_render', array('search_key' => $search_key));
-                }
-                else {
-                    // Redirect to search page
-                    $url = $this->generateURL('odr_search');
-                }
-            }
-*/
             if ($search_key == '')
                 $search_key = 'dt_id='.$datatype->getId();
 
             if ( count($remaining) > 0 ) {
-                // Redirect to search list
+                // Return to the list of datarecords since at least one datarecord of this datatype still exists
                 $url = $this->generateURL('odr_search_render', array('search_key' => $search_key));
             }
             else {
-                // Redirect to search page
-                $url = $this->generateURL('odr_search');
+                // ...otherwise, return to the list of datatypes
+                $url = $this->generateURL('odr_list_types', array('section' => 'records'));
             }
 
             $return['d'] = $url;

--- a/src/ODR/AdminBundle/Controller/RecordController.php
+++ b/src/ODR/AdminBundle/Controller/RecordController.php
@@ -330,10 +330,6 @@ class RecordController extends ODRCustomController
             $datarecord->setGrandparent($grandparent);
             $datarecord->setParent($parent);
             $em->persist($datarecord);
-
-            $grandparent->addChildren($datarecord); // TODO - needed?
-            $em->persist($grandparent);
-
             $em->flush();
 
             // Ensure the new child record has all its fields
@@ -1934,9 +1930,12 @@ if ($debug)
         $return['d'] = '';
 
         try {
+            // Don't actually need a search_key for a child reload, but GetDisplayData() expects the parameter
+            $search_key = '';
+
             $return['d'] = array(
                 'datarecord_id' => $datarecord_id,
-                'html' => self::GetDisplayData($request, $datarecord_id, 'child', $datatype_id),
+                'html' => self::GetDisplayData($request, $datarecord_id, $search_key, 'child', $datatype_id),
             );
         }
         catch (\Exception $e) {
@@ -2079,10 +2078,10 @@ if ($debug)
             // Determine if this is a 'child' render request for a top-level datatype
             $query = $em->createQuery(
                'SELECT dt.id AS dt_id
-                FROM ODRAdminBundle:DataTree dt
+                FROM ODRAdminBundle:DataTree AS dt
                 WHERE dt.deletedAt IS NULL AND dt.descendant = :datatype'
             )->setParameters( array('datatype' => $datatype->getId()) );
-            $results = $query->getResult();
+            $results = $query->getArrayResult();
 
             // If query found something, then it's not a top-level datatype
             if ( count($results) > 0 )

--- a/src/ODR/AdminBundle/Controller/WorkerController.php
+++ b/src/ODR/AdminBundle/Controller/WorkerController.php
@@ -259,12 +259,12 @@ $logger->info('WorkerController::recacherecordAction()  Attempting to recache Da
                     $short_form_html = parent::Short_GetDisplayData($request, $datarecord->getId());
                     $data = array( 'revision' => $current_revision, 'html' => $short_form_html );
                     $memcached->set($memcached_prefix.'.data_record_short_form_'.$datarecord_id, $data, 0);
-
+/*
                     // Render and cache the TextResults form of the record
                     $short_form_html = parent::Text_GetDisplayData($request, $datarecord->getId());
                     $data = array( 'revision' => $current_revision, 'html' => $short_form_html );
                     $memcached->set($memcached_prefix.'.data_record_short_text_form_'.$datarecord_id, $data, 0);
-
+*/
                     // Also render and store the public and non-public forms of the record
                     $long_form_html = parent::Long_GetDisplayData($request, $datarecord->getId(), 'force_render_all');
                     $data = array( 'revision' => $current_revision, 'html' => $long_form_html );

--- a/src/ODR/AdminBundle/Form/UpdateDataTypeForm.php
+++ b/src/ODR/AdminBundle/Form/UpdateDataTypeForm.php
@@ -7,6 +7,8 @@
 * (C) 2015 by Alex Pires (ajpires@email.arizona.edu)
 * Released under the GPLv2
 *
+* Builds the Form used for modifying Datatype properties via
+* the right slideout in DisplayTemplate.
 */
 
 //ODR/AdminBundle/Forms/UpdateDataTypeForm.class.php
@@ -28,37 +30,6 @@ class UpdateDataTypeForm extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-/*
-        $builder->add(
-            'createdBy',
-            'entity',
-            array(
-                'class' => 'ODR\OpenRepository\UserBundle\Entity\User',
-                'property' => 'id',
-            )
-        );
-
-        $builder->add(
-            'updatedBy',
-            'entity',
-            array(
-                'class' => 'ODR\OpenRepository\UserBundle\Entity\User',
-                'property' => 'id',
-                'attr'=>array('style'=>'display:none;')
-            )
-        );
-*/
-/*
-        $builder->add(
-            'render_plugin',
-            'entity',
-            array(
-                'class' => 'ODR\AdminBundle\Entity\RenderPlugin',
-                'property' => 'plugin_name',
-                'label' => 'Render Plugin',
-            )
-        );
-*/
         $builder->add(
             'short_name', 
             'text', 
@@ -113,9 +84,17 @@ class UpdateDataTypeForm extends AbstractType
             'entity',
             array(
                 'class' => 'ODR\AdminBundle\Entity\DataFields',
+/*
                 'query_builder' => function(EntityRepository $er) use ($datatype) {
                     return $er->createQueryBuilder('df')
                                 ->where('df.is_unique = 1 AND df.dataType = ?1')
+                                ->setParameter(1, $datatype);
+                },
+*/
+                'query_builder' => function(EntityRepository $er) use ($datatype) {
+                    return $er->createQueryBuilder('df')
+                                ->leftJoin('ODRAdminBundle:FieldType', 'ft', 'WITH', 'df.fieldType = ft')
+                                ->where('ft.canBeSortField = 1 AND df.dataType = ?1')
                                 ->setParameter(1, $datatype);
                 },
 
@@ -168,18 +147,6 @@ class UpdateDataTypeForm extends AbstractType
                 'empty_value' => false
             )
         );
-/*
-        $builder->add(
-            'public_date',
-            'datetime',
-            array(
-                'widget' => 'single_text',
-                'input' => 'datetime',
-                'required' => false,
-                'label'  => 'Public',
-            )
-        );
-*/
     }
     
     public function getName() {
@@ -187,11 +154,7 @@ class UpdateDataTypeForm extends AbstractType
     }
 
     /**
-     * TODO: short description.
-     * 
      * @param OptionsResolverInterface $resolver 
-     * 
-     * @return TODO
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {

--- a/src/ODR/AdminBundle/Resources/config/doctrine/IntegerValue.orm.yml
+++ b/src/ODR/AdminBundle/Resources/config/doctrine/IntegerValue.orm.yml
@@ -16,7 +16,8 @@ ODR\AdminBundle\Entity\IntegerValue:
         value:
             type: integer
             unsigned: false
-            nullable: false
+#            nullable: false
+            nullable: true
             gedmo:
                 - versioned
         deletedAt:

--- a/src/ODR/AdminBundle/Resources/config/routing.yml
+++ b/src/ODR/AdminBundle/Resources/config/routing.yml
@@ -1032,10 +1032,9 @@ odr_entity_check:
 odr_permission_check:
     pattern: /admin/permission_check
     defaults: { _controller: ODRAdminBundle:ODRUser:permissioncheck }
-
-#odr_radio_check:
-#    pattern: /admin/radio/test
-#    defaults: { _controller:ODRAdminBundle:Worker:testradio }
+odr_radio_check:
+    pattern: /admin/radio_check
+    defaults: { _controller:ODRAdminBundle:Worker:radiocheck }
 
 odr_start_encrypt:
     pattern: /admin/encrypt/{object_type}

--- a/src/ODR/AdminBundle/Resources/config/routing.yml
+++ b/src/ODR/AdminBundle/Resources/config/routing.yml
@@ -846,7 +846,7 @@ odr_csv_upload:
 odr_csv_cancel_import:
     pattern: /edit/csv_import/cancel
     defaults: { _controller: ODRAdminBundle:CSVImport:cancel }
-    
+
 odr_csv_import_layout:
     pattern: /edit/csv_import/layout/{datatype_id}
     defaults: { _controller: ODRAdminBundle:CSVImport:layout }
@@ -1032,9 +1032,15 @@ odr_entity_check:
 odr_permission_check:
     pattern: /admin/permission_check
     defaults: { _controller: ODRAdminBundle:ODRUser:permissioncheck }
-odr_radio_check:
-    pattern: /admin/radio_check
-    defaults: { _controller:ODRAdminBundle:Worker:radiocheck }
+
+odr_deleted_radio_check:
+    pattern: /admin/deleted_radio_check
+    defaults: { _controller:ODRAdminBundle:Worker:deletedradiocheck }
+odr_duplicate_radio_check:
+    pattern: /admin/duplicate_radio_check/{datatype_id}
+    defaults: { _controller:ODRAdminBundle:Worker:duplicateradiocheck }
+    requirements:
+        datatype_id: \d+
 
 odr_start_encrypt:
     pattern: /admin/encrypt/{object_type}

--- a/src/ODR/AdminBundle/Resources/views/CSVImport/uniqueness_warnings.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/CSVImport/uniqueness_warnings.html.twig
@@ -1,49 +1,20 @@
 {% spaceless %}
 
     {% set external_id_field = datatype.getexternalidfield %}
-    {% set name_field = datatype.getnamefield %}
-
-    {% if external_id_field != null and name_field != null and external_id_field.id == name_field.id %}
-        {% set external_id_field = null %}
-    {% endif %}
 
     <div class="csv_import_header pure-u-2-3">
-        {% if external_id_field == null and name_field == null %}
-            {# notify that the datatype doesn't have either type of identification field #}
+        {% if external_id_field == null %}
+            {# notify that the datatype doesn't have an external id field #}
             <div class="pure-u-1">
                 <span><i class="fa fa-lg fa-exclamation-triangle"></i></span>
-                <span>&nbsp;This Datatype doesn't have either an "External ID" Datafield or a "Name" Datafield...as such, the importing process is incapable of updating existing Datarecords.  Any rows imported will ALWAYS create new Datarecords.</span>
-            </div>
-
-        {% elseif external_id_field == null %}
-            {# since the datatype has no "external id" field, require "name" field #}
-            <div id="name_field_warning" class="pure-u-1">
-                <span><i class="fa fa-lg fa-exclamation-triangle"></i></span>
-                <span>&nbsp;This Datatype's Name Datafield, "{{ name_field.getfieldname }}", is currently not mapped to a column of the CSV File...as such, the importing process is incapable of updating existing Datarecords.  Any rows imported WILL create new Datarecords.</span>
-            </div>
-
-        {% elseif name_field == null %}
-            {# since the datatype has no "name" field, require "external id" field #}
-            <div id="external_id_field_warning" class="pure-u-1">
-                <span><i class="fa fa-lg fa-exclamation-triangle"></i></span>
-                <span>&nbsp;This Datatype's External ID Datafield, "{{ external_id_field.getfieldname }}", is currently not mapped to a column of the CSV File...as such, the importing process is incapable of updating existing Datarecords.  Any rows imported WILL create new Datarecords.</span>
+                <span>&nbsp;This Datatype doesn't have an "External ID" Datafield...as such, the importing process is incapable of updating existing Datarecords.  Any rows imported will ALWAYS create new Datarecords.</span>
             </div>
 
         {% else %}
-            {# need a single warning when neither field is set... #}
-            <div id="both_fields_warning" class="pure-u-1">
+            {# notify that the external id field is not mapped #}
+            <div id="external_id_field_warning" class="pure-u-1">
                 <span><i class="fa fa-lg fa-exclamation-triangle"></i></span>
-                <span>&nbsp;Neither this Datatype's External ID Datafield, "{{ external_id_field.getfieldname }}", nor this Datatype's Name Datafield, "{{ name_field.getfieldname }}", are currently mapped to a column of the CSV File...as such, the importing process is incapable of updating existing Datarecords.  Any rows imported WILL create new Datarecords, and both these Datafields will have multiple blank values.</span>
-            </div>
-
-            {# ...also need default empty unique datafield warnings #}
-            <div id="external_id_field_notice" class="pure-u-1 ODRHidden">
-                <span><i class="fa fa-lg fa-exclamation-circle"></i></span>
-                <span>&nbsp;This Datatype's External ID Datafield, "{{ external_id_field.getfieldname }}", is currently not mapped to a column of the CSV File...if any new Datarecords are created as a result of this import, this datafield will have multiple blank values.</span>
-            </div>
-            <div id="name_field_notice" class="pure-u-1 ODRHidden">
-                <span><i class="fa fa-lg fa-exclamation-circle"></i></span>
-                <span>&nbsp;This Datatype's Name Datafield, "{{ name_field.getfieldname }}", is currently not mapped to a column of the CSV File...if any new Datarecords are created as a result of this import, this datafield will have multiple blank values.</span>
+                <span>&nbsp;This Datatype's External ID Datafield, "{{ external_id_field.getfieldname }}", is currently not mapped to a column of the CSV File...as such, the importing process is incapable of updating existing Datarecords.  Any rows imported WILL create new Datarecords.</span>
             </div>
 
         {% endif %}
@@ -67,24 +38,9 @@
 
 <script>
     function updateHeaderWarnings() {
-{% if external_id_field == null and name_field == null %}
-        /* no external id or name datafield, do nothing for them*/
-{% elseif external_id_field == null %}
-        // Check to see if the name datafield is mapped to a csv column
-        var selected = false;
-        $(".datafield_mapping:enabled").each(function() {
-            var selected_df = $(this).children('option:selected').val();
-            if ( selected_df == "{{ name_field.id }}" )
-                selected = true;
-        });
-
-        // Display the warning based on whether it is
-        if (selected)
-            $("#name_field_warning").hide();
-        else
-            $("#name_field_warning").show();
-
-{% elseif name_field == null %}
+{% if external_id_field == null %}
+        /* no external id datafield, do nothing */
+{% else %}
         // Check to see if the external id datafield is mapped to a csv column
         var selected = false;
         $(".datafield_mapping:enabled").each(function() {
@@ -99,43 +55,6 @@
         else
             $("#external_id_field_warning").show();
 
-{% else %}
-        // Check to see if the name datafield is mapped to a csv column
-        var has_name_field = false;
-        $(".datafield_mapping:enabled").each(function() {
-            var selected_df = $(this).children('option:selected').val();
-            if ( selected_df == "{{ name_field.id }}" )
-                has_name_field = true;
-        });
-
-        // Check to see if the external id datafield is mapped to a csv column
-        var has_external_id_field = false;
-        $(".datafield_mapping:enabled").each(function() {
-            var selected_df = $(this).children('option:selected').val();
-            if ( selected_df == "{{ external_id_field.id }}" )
-                has_external_id_field = true;
-        });
-
-        // Default
-        $("#both_fields_warning").hide();
-        $("#external_id_field_notice").hide();
-        $("#name_field_notice").hide();
-
-        if (has_name_field && has_external_id_field) {
-            /* do nothing */
-        }
-        else if (has_name_field) {
-            // Name field is mapped
-            $("#external_id_field_notice").show();
-        }
-        else if (has_external_id_field) {
-            // External ID field is mapped
-            $("#name_field_notice").show();
-        }
-        else {
-            // Neither field is mapped
-            $("#both_fields_warning").show();
-        }
 {% endif %}
 
         // Deal with unique datafields that aren't external id/name datafields

--- a/src/ODR/AdminBundle/Resources/views/Datatype/edit_datatype_properties.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Datatype/edit_datatype_properties.html.twig
@@ -24,7 +24,8 @@
                 <label for="namefield_select">Name Field:</label>
                 <select id="namefield_select" name="name_datafield" onchange="SaveNameField({{ datatype.id }});">
                     <option value="-1" {% if datatype.getnamefield == null %}selected{% endif %}>NONE</option>
-                    {% for datafield in unique_datafields %}
+                    {#{% for datafield in unique_datafields %}#}
+                    {% for datafield in sort_datafields %}
                         <option value="{{ datafield.id }}" {% if datatype.getnamefield != null and datatype.getnamefield.id == datafield.id %}selected{% endif %}>{{ datafield.getfieldname }}</option>
                     {% endfor %}
                 </select>

--- a/src/ODR/AdminBundle/Resources/views/Displaytemplate/design_ajax.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Displaytemplate/design_ajax.html.twig
@@ -1006,7 +1006,7 @@ function SetupDataFields() {
 
         // Check if this field is already loaded
         var form_id = "";
-        var form = $("#ElementData").find("form");
+        var form = $("#ElementData").find("form.ODRDatafieldPropertiesForm");
         if (form.length > 0) {
             var form_id_data = form.attr("id").split(/_/);;
             form_id = form_id_data[1];

--- a/src/ODR/AdminBundle/Resources/views/Job/csv_export.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Job/csv_export.html.twig
@@ -25,7 +25,7 @@
         ajax_url += job_type;
 
         var table = $("#ODRJobList_" + job_type).dataTable({
-            columns: [
+            "columns": [
                 { "data": "created_at" },
                 { "data": "created_by" },
                 { "data": "description" },
@@ -53,16 +53,20 @@
                 },
             ],
 
-            lengthChange: false,
-            info: false,
-            ordering: false,
-            searching: false,
-            paging: false,
+            "lengthChange": false,
+            "info": false,
+            "ordering": false,
+            "searching": false,
+            "paging": false,
+
+            "language": {
+                "emptyTable": "No Jobs found"
+            },
 
             // https://datatables.net/manual/server-side
-            processing: true,   // only displays a little "processing..." blurb
+            "processing": true,   // only displays a little "processing..." blurb
 
-            ajax: {
+            "ajax": {
                 url: ajax_url,
                 type: "GET",
                 dataSrc: "d",

--- a/src/ODR/AdminBundle/Resources/views/Job/csv_import_validate.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Job/csv_import_validate.html.twig
@@ -25,7 +25,7 @@
         ajax_url += job_type;
 
         var table = $("#ODRJobList_" + job_type).dataTable({
-            columns: [
+            "columns": [
                 { "data": "created_at" },
                 { "data": "created_by" },
                 { "data": "description" },
@@ -53,16 +53,20 @@
                 },
             ],
 
-            lengthChange: false,
-            info: false,
-            ordering: false,
-            searching: false,
-            paging: false,
+            "lengthChange": false,
+            "info": false,
+            "ordering": false,
+            "searching": false,
+            "paging": false,
+
+            "language": {
+                "emptyTable": "No Jobs found"
+            },
 
             // https://datatables.net/manual/server-side
-            processing: true,   // only displays a little "processing..." blurb
+            "processing": true,   // only displays a little "processing..." blurb
 
-            ajax: {
+            "ajax": {
                 url: ajax_url,
                 type: "GET",
                 dataSrc: "d",

--- a/src/ODR/AdminBundle/Resources/views/Job/list.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Job/list.html.twig
@@ -107,7 +107,7 @@
             ajax_url += job_type;
 
             var table = $("#ODRJobList_" + job_type).dataTable({
-                columns: [
+                "columns": [
                     { "data": "created_at" },
                     { "data": "created_by" },
                     { "data": "description" },
@@ -121,18 +121,22 @@
                     { "data": "eta" },
                 ],
 
-                lengthChange: false,
-                info: false,
-                ordering: false,
-                searching: false,
-                paging: false,
+                "lengthChange": false,
+                "info": false,
+                "ordering": false,
+                "searching": false,
+                "paging": false,
 //                autoWidth: false,
 
+                "language": {
+                    "emptyTable": "No Jobs found"
+                },
+
                 // https://datatables.net/manual/server-side
-                processing: true,   // only displays a little "processing..." blurb
+                "processing": true,   // only displays a little "processing..." blurb
 //                serverSide: true,
 
-                ajax: {
+                "ajax": {
                     url: ajax_url,
                     type: "GET",
                     dataSrc: "d",

--- a/src/ODR/AdminBundle/Resources/views/Job/recache.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Job/recache.html.twig
@@ -24,7 +24,7 @@
         ajax_url += job_type;
 
         var table = $("#ODRJobList_" + job_type).dataTable({
-            columns: [
+            "columns": [
                 { "data": "description" },
                 { "data": "revision" },
                 {
@@ -37,16 +37,20 @@
                 { "data": "eta" },
             ],
 
-            lengthChange: false,
-            info: false,
-            ordering: false,
-            searching: false,
-            paging: false,
+            "lengthChange": false,
+            "info": false,
+            "ordering": false,
+            "searching": false,
+            "paging": false,
+
+            "language": {
+                "emptyTable": "No Jobs found"
+            },
 
             // https://datatables.net/manual/server-side
-            processing: true,   // only displays a little "processing..." blurb
+            "processing": true,   // only displays a little "processing..." blurb
 
-            ajax: {
+            "ajax": {
                 url: ajax_url,
                 type: "GET",
                 dataSrc: "d",

--- a/src/ODR/AdminBundle/Resources/views/ODRUser/create.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/ODRUser/create.html.twig
@@ -28,7 +28,7 @@
             {{ form_errors(profile_form.email) }}
             {{ form_widget(profile_form.email, { 'attr': {'class': 'required', 'data-error-type': 'inline' } }) }}
             <span style="margin: 5px;">
-                <button id="emailCheckButton" type="button" class="pure-button pure-button-primary" onclick="checkEmail();">Check</button>
+                <button id="emailCheckButton" type="button" class="pure-button pure-button-primary" onclick="checkEmail();">Check Availability</button>
             </span>
             <span id="email_errors" style="margin: 5px;"></span>
         </div>
@@ -90,7 +90,7 @@
 
     </fieldset>
 
-    <input id="submitButton" class="pure-button pure-button-primary" type="button" />
+    <input id="submitButton" class="pure-button pure-button-primary" type="button" value="Save" />
 
 </form>
 
@@ -120,15 +120,15 @@
         });
 
         var old_email = '';
-        $("#submitButton").hide();
+        $("#submitButton").removeClass('pure-button-primary').attr('disabled', 'disabled');
         $("#{{ profile_form.email.vars.id }}").unbind('keyup').unbind('paste');
         $("#{{ profile_form.email.vars.id }}").on('keyup paste', function() {
             var new_email = $(this).val();
             if (old_email != new_email) {
                 old_email = new_email;
 
-                $("#emailCheckButton").addClass('pure-button-primary').html('Check').removeAttr('disabled');
-                $("#submitButton").hide();
+                $("#emailCheckButton").addClass('pure-button-primary').html('Check Availability').removeAttr('disabled');
+                $("#submitButton").removeClass('pure-button-primary').attr('disabled', 'disabled');
             }
         });
     });
@@ -139,7 +139,8 @@
         var email = $("#{{ profile_form.email.vars.id }}").val();
         email = email.trim();
 
-        if (email == '')
+        // Require a valid email address before sending an ajax request
+        if ( !$("input[name='{{ profile_form.email.vars.full_name }}']").valid() )
             return;
 
         $.ajax({
@@ -153,11 +154,11 @@
 
                     if (data.d == 0) {
                         // Email not found
-                        $("#submitButton").show().attr('value', 'Save').attr('onclick', 'saveProfileForm();').removeAttr('disabled');
+                        $("#submitButton").addClass('pure-button-primary').attr('value', 'Save').attr('onclick', 'saveProfileForm();').removeAttr('disabled');
                     }
                     else {
                         // Email already exists
-                        $("#submitButton").show().attr('value', 'View Permissions').attr('onclick', 'viewPermissions(' + data.d + ');').removeAttr('disabled');
+                        $("#submitButton").addClass('pure-button-primary').attr('value', 'View Permissions').attr('onclick', 'viewPermissions(' + data.d + ');').removeAttr('disabled');
                         $("#emailCheckButton").html('User already exists');
                     }
                 }

--- a/src/ODR/AdminBundle/Resources/views/Record/record_ajax.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Record/record_ajax.html.twig
@@ -442,8 +442,6 @@ function initPage() {
                 dataType: dataType,
                 success: function(data, textStatus, jqXHR) {
                     if(data.r == 0) {
-                        // TODO - shouldn't this be handled entirely via javascript instead of another ajax call?
-
                         // Refresh child wrapper area
                         var datatype_id = data.d.datatype_id;
                         var parent_id = data.d.parent_id;
@@ -1057,7 +1055,8 @@ function ReloadChild(datatype_id, datarecord_id) {
         dataType: dataType,
         success: function(data, textStatus, jqXHR) {
             if (data.r == 0) {
-                $("#ChildTypeWrapper_" + datatype_id + "_" + datarecord_id).prepend(data.d.html);
+                // The returned html includes #ChildTypeWrapper...completely overwrite the contents of its parent div
+                $("#ChildTypeWrapper_" + datatype_id + "_" + datarecord_id).parent(".ODRInnerBox").html(data.d.html);
 
                 setupAccordions();
                 initPage();

--- a/src/ODR/AdminBundle/Resources/views/Record/record_area_child_load.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Record/record_area_child_load.html.twig
@@ -1,4 +1,16 @@
 {% spaceless %}
-    {% import "ODRAdminBundle:Record:record_childtype.html.twig" as mychildform %}
-    {{ mychildform.input(datatype_tree, datarecord_tree, theme, datatype_permissions, datafield_permissions) }}
+
+{% set datatype = datatype_tree.datatype %}
+
+{% set can_edit_record = 0 %}
+{% set can_add_record = 0 %}
+{% if datatype_permissions[ datatype.id ] is defined and datatype_permissions[ datatype.id ][ 'edit' ] is defined %}
+    {% set can_edit_record = 1 %}
+{% endif %}
+{% if datatype_permissions[ datatype.id ] is defined and datatype_permissions[ datatype.id ][ 'add' ] is defined %}
+    {% set can_add_record = 1 %}
+{% endif %}
+
+    {% include 'ODRAdminBundle:Record:record_fields_childtype.html.twig' with {'datatype_tree': datatype_tree, 'datarecord_children': datarecord_tree, 'theme': theme, 'datatype_permissions': datatype_permissions, 'datafield_permissions': datafield_permissions, 'can_edit_record': can_edit_record, 'can_add_record': can_add_record, 'parent_datarecord': parent_datarecord} %}
+
 {% endspaceless %}

--- a/src/ODR/AdminBundle/Resources/views/Record/record_datafield.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Record/record_datafield.html.twig
@@ -188,7 +188,8 @@
             </div>
         </fieldset>
 
-    {% elseif field_typename == "Single Radio" or field_typename == "Multiple Radio" %}
+    {#{% elseif field_typename == "Single Radio" or field_typename == "Multiple Radio" %}#}
+    {% elseif field_typename == "Single Radio" or field_typename == "Multiple Radio" or field_typename == "Multiple Select" %}
         <fieldset>
             <label id="Label_{{ field.id }}" class="ODRFieldLabel ODRDatafieldHistory pure-u-1" title="{{ field.description }}">{{ field.fieldname }}</label>
 
@@ -209,7 +210,8 @@
 
         <fieldset>
 
-    {% elseif field_typename == "Single Select" or field_typename == "Multiple Select" %}
+    {#{% elseif field_typename == "Single Select" or field_typename == "Multiple Select" %}#}
+    {% elseif field_typename == "Single Select" %}
         <fieldset>
             <label id="Label_{{ field.id }}" for="SelectGroup_{{ datarecordfield.id }}" class="ODRFieldLabel ODRDatafieldHistory pure-u-1" title="{{ field.description }}">{{ field.getFieldName }}</label>
 

--- a/src/ODR/AdminBundle/Resources/views/Record/record_fields.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Record/record_fields.html.twig
@@ -78,30 +78,7 @@
                 {% set datarecord_children = dr_entry.child_datarecords[childtype.id] %}
             {% endif %}
 
-            <div class="ODRChildDatatype" id="ChildTypeWrapper_{{ childtype.id }}_{{ datarecord.id }}">
-{#
-                {% if data.datatype.is_link == 1 %}
-                    {% import "ODRAdminBundle:Results:results_childtype.html.twig" as mychildform %}
-                    {{ mychildform.input(data.datatype, datarecord_children, theme, false) }}
-                {% else %}
-#}
-                    {% import "ODRAdminBundle:Record:record_childtype.html.twig" as mychildform %}
-                    {{ mychildform.input(data.datatype, datarecord_children, theme, datatype_permissions, datafield_permissions) }}
-{#
-                {% endif %}
-#}
-                <div>
-                {% if data.datatype.is_link == 1 %}
-                    {% if can_edit_record == 1 %}
-                    <button class="pure-button pure-button-primary" type="button" onclick="LinkRecord({{ datatype.id }},{{ childtype.id }},{{ datarecord.id }});">Link {{ childtype.shortname }} record.</button>
-                    {% endif %}
-                {% elseif childtype.multiplerecordsperparent > 0 %}
-                    {% if can_add_record == 1 %}
-                    <button class="pure-button pure-button-primary" type="button" onclick="AddChildRecord({{ childtype.id }},{{ datarecord.id }},{{ datarecord.grandparent.id }});">Add {{ childtype.shortname }} record.</button>
-                    {% endif %}
-                {% endif %}
-                </div>
-            </div><!-- End of #ChildTypeWrapper_{{ childtype.id }}_{{ datarecord.id }} -->
+            {% include 'ODRAdminBundle:Record:record_fields_childtype.html.twig' with {'datatype_tree': data.datatype, 'datarecord_children': datarecord_children, 'theme': theme, 'datatype_permissions': datatype_permissions, 'datafield_permissions': datafield_permissions, 'can_edit_record': can_edit_record, 'can_add_record': can_add_record, 'parent_datarecord': datarecord} %}
 
         {% endif %}
 

--- a/src/ODR/AdminBundle/Resources/views/Record/record_fields_childtype.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Record/record_fields_childtype.html.twig
@@ -1,0 +1,30 @@
+{% spaceless %}
+
+    {% set childtype = datatype_tree.datatype %}
+
+    <div class="ODRChildDatatype" id="ChildTypeWrapper_{{ childtype.id }}_{{ parent_datarecord.id }}">
+{#
+    {% if data.datatype.is_link == 1 %}
+        {% import "ODRAdminBundle:Results:results_childtype.html.twig" as mychildform %}
+        {{ mychildform.input(data.datatype, datarecord_children, theme, false) }}
+    {% else %}
+#}
+        {% import "ODRAdminBundle:Record:record_childtype.html.twig" as mychildform %}
+        {{ mychildform.input(datatype_tree, datarecord_children, theme, datatype_permissions, datafield_permissions) }}
+{#
+    {% endif %}
+#}
+        <div>
+        {% if datatype_tree.is_link == 1 %}
+            {% if can_edit_record == 1 %}
+            <button class="pure-button pure-button-primary" type="button" onclick="LinkRecord({{ datatype.id }},{{ childtype.id }},{{ parent_datarecord.id }});">Link {{ childtype.shortname }} record.</button>
+            {% endif %}
+        {% elseif can_add_record == 1 %}
+            {% if childtype.multiplerecordsperparent > 0 or datarecord_children|length < 1 %}
+            <button class="pure-button pure-button-primary" type="button" onclick="AddChildRecord({{ childtype.id }},{{ parent_datarecord.id }},{{ parent_datarecord.grandparent.id }});">Add {{ childtype.shortname }} record.</button>
+            {% endif %}
+        {% endif %}
+        </div>
+    </div><!-- End of #ChildTypeWrapper_{{ childtype.id }}_{{ parent_datarecord.id }} -->
+
+{% endspaceless %}

--- a/src/ODR/AdminBundle/Tests/Controller/DefaultControllerTest.php
+++ b/src/ODR/AdminBundle/Tests/Controller/DefaultControllerTest.php
@@ -6,12 +6,46 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class DefaultControllerTest extends WebTestCase
 {
+    public static $client = "";
+
+    /**
+     * testIndex
+     *
+     * DEBUG=DefaultController ./vendor/phpunit/phpunit/phpunit -c app/
+     *
+     *
+     */
     public function testIndex()
     {
-        $client = static::createClient();
+        $debug = (getenv("DEBUG") == "DefaultController" ? true: false);
+        self::$client = static::createClient();
 
-        $crawler = $client->request('GET', '/hello/Fabien');
+        // Test that the outer frame loaded
+        ($debug ? fwrite(STDERR, "Test the outer frame loaded.\n"):'');
+        $crawler = self::$client->request('GET', 'http://odr.localhost/admin');
 
-        $this->assertTrue($crawler->filter('html:contains("Hello Fabien")')->count() > 0);
+        // Show the actual content if debug enabled.
+        ($debug ? fwrite(STDERR, self::$client->getResponse()->getContent()) . "\n":'');
+
+        // Should redirect to login
+        ($debug ? fwrite(STDERR, "Should redirect to login.\n"):'');
+        $this->assertTrue($crawler->filter('html:contains("Redirecting to")')->count() > 0);
+    }
+
+    /**
+     *
+     */
+    public function testIndex2()
+    {
+        $debug = (getenv("DEBUG") == "DefaultController" ? true: false);
+
+        // Test that the outer frame loaded
+        ($debug ? fwrite(STDERR, "Test the outer frame loaded.\n"):'');
+        $crawler = self::$client->request('GET', 'http://odr.localhost/admin');
+        ($debug ? fwrite(STDERR, self::$client->getResponse()->getContent()) . "\n":'');
+
+        // Should redirect to login
+        ($debug ? fwrite(STDERR, "222Should redirect to login.\n"):'');
+        $this->assertTrue($crawler->filter('html:contains("Redirecting to")')->count() > 0);
     }
 }


### PR DESCRIPTION
Important
- changed the "create new user" page to make it more obvious that you need to check availability of email address before saving the new user
- fixed a crash that would happen when a new child datarecord was created
- fixed two UI bugs that would appear after creating/deleting child datarecords
- datatypes no longer revert back to "accordion" display when a change is made to their render plugin
- site should redirect properly (again) when the last datarecord of a datatype is deleted
- datarecord lists no longer display filename or download link for a file if the user doesn't have permissions to view the file in the first place
- external id shows up in CSV exports again
- integer field can store an empty string
- fixed a crash that had happened a few times when changing a datafield's fieldtype
- the "Name Field" for a datatype is no longer required to be unique, and no longer "kinda does the same thing as external ID" in CSV imports

Not as important
- fixed several places where user-related functions would refuse to work if no datatypes existed
- fixed several other errors revealed by a fresh install of ODR

Temporary
- Multiple Select datafields temporarily changed to render like Multiple Radio, because the default HTML and event handling for Multiple Select in browsers is terrible