### PR TITLE
1.1.6 - UI fixes for handling larger files, searching and MassEdit work on child Datatypes

### DIFF
--- a/src/ODR/AdminBundle/Controller/CSVImportController.php
+++ b/src/ODR/AdminBundle/Controller/CSVImportController.php
@@ -2689,7 +2689,8 @@ print_r($new_mapping);
                             }
 
                             // Store the path to the user's upload area...
-                            $storage_filepath = dirname(__FILE__).'/../../../../web/uploads/csv/user_'.$user->getId().'/storage';
+                            $path_prefix = dirname(__FILE__).'/../../../../web/';
+                            $storage_filepath = 'uploads/csv/user_'.$user->getId().'/storage';
 
                             // Grab a list of the files/images already uploaded to this datafield
                             $existing_files = array();
@@ -2719,12 +2720,12 @@ print_r($new_mapping);
 
                                     $status .= '      ...uploaded new '.$typeclass.' ("'.$csv_filename.'")'."\n";
                                 }
-                                else if ( $existing_files[$csv_filename]->getOriginalChecksum() == md5_file($storage_filepath.'/'.$csv_filename) ) {
+                                else if ( $existing_files[$csv_filename]->getOriginalChecksum() == md5_file($path_prefix.$storage_filepath.'/'.$csv_filename) ) {
                                     // ...the specified file/image is already in datafield
                                     $status .= '      ...'.$typeclass.' ("'.$csv_filename.'") is an exact copy of existing version, skipping.'."\n";
 
                                     // Delete the file/image from the server since it already officially exists
-                                    unlink($storage_filepath.'/'.$csv_filename);
+                                    unlink($path_prefix.$storage_filepath.'/'.$csv_filename);
                                 }
                                 else {
                                     // ...need to "update" the existing file/image
@@ -2732,9 +2733,9 @@ print_r($new_mapping);
 
                                     // Determine the path to the current file/image
                                     $my_obj = $existing_files[$csv_filename];
-                                    $local_filepath = dirname(__FILE__).'/../../../../web/uploads/files/File_';
+                                    $local_filepath = $path_prefix.'uploads/files/File_';
                                     if ($typeclass == 'Image')
-                                        $local_filepath = dirname(__FILE__).'/../../../../web/uploads/images/Image_';
+                                        $local_filepath = $path_prefix.'uploads/images/Image_';
                                     $local_filepath .= $my_obj->getId().'.'.$my_obj->getExt();
 
                                     $handle = fopen($local_filepath, 'w');
@@ -2742,12 +2743,12 @@ print_r($new_mapping);
                                         throw new \Exception('Could not write to '.$local_filepath);
 
                                     // Update the current file/image with the new contents
-                                    $file_contents = file_get_contents($storage_filepath.'/'.$csv_filename);
+                                    $file_contents = file_get_contents($path_prefix.$storage_filepath.'/'.$csv_filename);
                                     fwrite($handle, $file_contents);
                                     fclose($handle);
 
                                     // Delete the uploaded file/image from the storage directory
-                                    unlink($storage_filepath.'/'.$csv_filename);
+                                    unlink($path_prefix.$storage_filepath.'/'.$csv_filename);
                                     $status .= 'overwritten...';
 
                                     // Update other properties of the file/image that got changed

--- a/src/ODR/AdminBundle/Controller/FlowController.php
+++ b/src/ODR/AdminBundle/Controller/FlowController.php
@@ -253,11 +253,12 @@ class FlowController extends ODRCustomController
             }
 
             // Check whether file is uploaded completely and properly
-            $destination_folder = dirname(__FILE__).'/../../../../web/uploads/files/chunks/user_'.$user_id.'/completed';
-            if ( !file_exists($destination_folder) )
-                mkdir( $destination_folder );
+            $path_prefix = dirname(__FILE__).'/../../../../web/';
+            $destination_folder = 'uploads/files/chunks/user_'.$user_id.'/completed';
+            if ( !file_exists($path_prefix.$destination_folder) )
+                mkdir( $path_prefix.$destination_folder );
 
-            $destination = $destination_folder.'/'.$original_filename;
+            $destination = $path_prefix.$destination_folder.'/'.$original_filename;
 
             if ( self::validateFile($user_id, $identifier, $total_chunks, $expected_size) && self::saveFile($user_id, $identifier, $total_chunks, $destination) ) {
                 // All file chunks sucessfully uploaded and spliced back together
@@ -276,11 +277,11 @@ class FlowController extends ODRCustomController
 
                 if ($upload_type == 'csv') {
                     // Upload is a CSVImport file
-                    self::finishCSVUpload($destination_folder, $original_filename, $user_id, $request);
+                    self::finishCSVUpload($path_prefix.$destination_folder, $original_filename, $user_id, $request);
                 }
                 else if ($upload_type == 'xml') {
                     // Upload is an XMLImport file
-                    self::finishXMLUpload($destination_folder, $original_filename, $user_id, $request);
+                    self::finishXMLUpload($path_prefix.$destination_folder, $original_filename, $user_id, $request);
                 }
                 else if ($datafield_id !== null) {
                     // Upload meant for a file/image datafield...finish moving the uploaded file and store it properly
@@ -288,8 +289,8 @@ class FlowController extends ODRCustomController
                 }
                 else {
                     // Upload is a file/image meant to be referenced by a later XML/CSV Import
-                    $uploaded_file->move( $destination_folder, $original_filename );
-                    self::finishImportFileUpload($destination_folder, $original_filename, $user_id, $upload_type);
+                    $uploaded_file->move( $path_prefix.$destination_folder, $original_filename );
+                    self::finishImportFileUpload($path_prefix.$destination_folder, $original_filename, $user_id, $upload_type);
                 }
 
                 // Return success

--- a/src/ODR/AdminBundle/Controller/ODRCustomController.php
+++ b/src/ODR/AdminBundle/Controller/ODRCustomController.php
@@ -479,6 +479,7 @@ print "\n\n";
                 $data['error'] = true;
                 $data['message'] = $ret['message'];
                 $data['encoded_search_key'] = $ret['encoded_search_key'];
+                $data['complete_datarecord_list'] = '';
                 $data['datarecord_list'] = '';
 
                 return $data;
@@ -499,7 +500,8 @@ print "\n\n";
         $data['searched_datafields'] = $search_params['searched_datafields'];
         $data['encoded_search_key'] = $search_params['encoded_search_key'];
 
-        $data['datarecord_list'] = $search_params[$str]['datarecord_list'];
+        $data['datarecord_list'] = $search_params[$str]['datarecord_list'];                     // ...just top-level datarecords
+        $data['complete_datarecord_list'] = $search_params[$str]['complete_datarecord_list'];   // ...top-level, child, and linked datarecords
 
         return $data;
     }
@@ -1663,6 +1665,7 @@ $save_permissions = false;
 //print_r($results);
 
 
+                // TODO - why is this here?  does mysql not handle ordering properly in this case?
                 // Flatten the array
                 $datarecords = array();
                 foreach ($results as $num => $data) {

--- a/src/ODR/AdminBundle/Controller/ODRCustomController.php
+++ b/src/ODR/AdminBundle/Controller/ODRCustomController.php
@@ -2707,6 +2707,7 @@ $save_permissions = false;
         $results = $query->getArrayResult();
         foreach ($results as $num => $data) {
             $fieldname = $data['field_name'];
+            $fieldname = str_replace('"', "\\\"", $fieldname);
             $column_names .= '{"title":"'.$fieldname.'"},';
             $num_columns++;
         }

--- a/src/ODR/AdminBundle/Controller/ODRCustomController.php
+++ b/src/ODR/AdminBundle/Controller/ODRCustomController.php
@@ -75,9 +75,12 @@ class ODRCustomController extends Controller
         $session = $this->get('session');
         $repo_datarecord = $this->getDoctrine()->getManager()->getRepository('ODRAdminBundle:DataRecord');
 
+        $logged_in = false;
         $user_permissions = array();
-        if ($user !== 'anon.')
+        if ($user !== 'anon.') {
+            $logged_in = true;
             $user_permissions = self::getPermissionsArray($user->getId(), $request);
+        }
 
         // Grab the tab's id, if it exists
         $params = $request->query->all();
@@ -167,6 +170,8 @@ class ODRCustomController extends Controller
                     'user_permissions' => $user_permissions,
                     'odr_tab_id' => $odr_tab_id,
 
+                    'logged_in' => $logged_in,
+
                     // required for load_datarecord_js.html.twig
                     'target' => $target,
                     'search_key' => $search_key,
@@ -206,6 +211,8 @@ print "\n\n";
                     'scroll_target' => $scroll_target,
                     'user' => $user,
                     'user_permissions' => $user_permissions,
+
+                    'logged_in' => $logged_in,
 
                     // required for load_datarecord_js.html.twig
                     'target' => $target,
@@ -3703,6 +3710,8 @@ if ($debug) {
                         WHERE dt.ancestor = :ancestor AND dt.descendant = :descendant AND dt.deletedAt IS NULL'
                     )->setParameters( array('ancestor' => $datatype, 'descendant' => $childtype) );
                     $result = $query->getResult();
+
+                    // TODO - empty query results?
 
                     $tree['has_childtype'] = 1;
                     $top_level = 0;

--- a/src/ODR/AdminBundle/Controller/ODRCustomController.php
+++ b/src/ODR/AdminBundle/Controller/ODRCustomController.php
@@ -653,7 +653,6 @@ print "\n\n";
                 $checksum = md5_file($encrypted_basedir.'enc.'.$chunk_id);
 
                 // Attempt to load a checksum object
-                // TODO: is this always going to be null?
                 $obj = null;
                 if ($object_type == 'file')
                     $obj = $repo_filechecksum->findOneBy( array('File' => $object_id, 'chunk_id' => $chunk_id) );

--- a/src/ODR/AdminBundle/Controller/RecordController.php
+++ b/src/ODR/AdminBundle/Controller/RecordController.php
@@ -727,9 +727,15 @@ class RecordController extends ODRCustomController
 
 
             // If the file is public, make it non-public...if file is non-public, make it public
+            $public_date = null;
             if ( $file->isPublic() ) {
                 // Make the record non-public
-                $file->setPublicDate(new \DateTime('2200-01-01 00:00:00'));
+                $public_date = new \DateTime('2200-01-01 00:00:00');
+                $file->setPublicDate($public_date);
+
+                $file->setUpdatedBy($user);
+                $em->persist($file);
+                $em->flush();
 
                 // Delete the decrypted version of the file, if it exists
                 $file_upload_path = dirname(__FILE__).'/../../../../web/uploads/files/';
@@ -741,21 +747,22 @@ class RecordController extends ODRCustomController
             }
             else {
                 // Make the record public
-                $file->setPublicDate(new \DateTime());
+                $public_date = new \DateTime();
+                $file->setPublicDate($public_date);
+
+                $file->setUpdatedBy($user);
+                $em->persist($file);
+                $em->flush();
 
                 // Immediately decrypt the file
                 parent::decryptObject($file->getId(), 'file');
             }
 
-            $file->setUpdatedBy($user);
-            $em->persist($file);
-            $em->flush();
-
             // Need to rebuild this particular datafield's html to reflect the changes...
             $return['t'] = 'html';
             $return['d'] = array(
-                'datarecord' => $datarecord->getId(),
-                'datafield' => $datafield->getId()
+                'is_public' => $file->isPublic(),
+                'public_date' => $public_date->format('Y-m-d'),
             );
 
             // Determine whether ShortResults needs a recache

--- a/src/ODR/AdminBundle/Controller/ReportsController.php
+++ b/src/ODR/AdminBundle/Controller/ReportsController.php
@@ -766,11 +766,10 @@ print_r($grandparent_list);
 
             // Shouldn't really be necessary if the file is public, but including anyways for completeness/later use
             if ( $file->isPublic() ) {
-                $absolute_path = realpath( $file->getUploadDir().'/'.$file->getLocalFileName() );
+                $absolute_path = realpath( dirname(__FILE__).'/../../../../web/'.$file->getLocalFileName() );
 
                 if (!$absolute_path) {
-                    // File doesn't exist for some reason...
-                    // TODO - decrypt it?
+                    // File doesn't exist, so no progress yet
                 }
                 else {
                     // Grab current filesize of file
@@ -787,7 +786,7 @@ print_r($grandparent_list);
                 $absolute_path = realpath( dirname(__FILE__).'/../../../../web/uploads/files/'.$temp_filename );
 
                 if (!$absolute_path) {
-                    // File doesn't exist
+                    // File doesn't exist, so no progress yet
                 }
                 else {
                     // Grab current filesize of file

--- a/src/ODR/AdminBundle/Controller/ReportsController.php
+++ b/src/ODR/AdminBundle/Controller/ReportsController.php
@@ -858,7 +858,7 @@ print_r($grandparent_list);
 
             $progress = array('current_value' => 100, 'max_value' => 100);
 
-            if ($file->getOriginalChecksum() === '') {
+            if ($file->getOriginalChecksum() == null || $file->getOriginalChecksum() == '') {
                 // TODO - load from config file somehow?
                 $crypto_dir = dirname(__FILE__).'/../../../../app/crypto_dir/File_'.$file_id;
                 $chunk_size = 2 * 1024 * 1024;  // 2Mb in bytes
@@ -870,6 +870,10 @@ print_r($grandparent_list);
                     $files = scandir($crypto_dir);
                     // TODO - assumes linux machine
                     $progress['current_value'] = intval((floatval(count($files) - 2) / floatval($num_chunks)) * 100);
+                }
+                else {
+                    // Encrypted directory doesn't exist yet, so no progress has been made
+                    $progress['current_value'] = 0;
                 }
             }
 

--- a/src/ODR/AdminBundle/Controller/ResultsController.php
+++ b/src/ODR/AdminBundle/Controller/ResultsController.php
@@ -435,8 +435,8 @@ class ResultsController extends ODRCustomController
             if ( $file->isPublic() ) {
                 $local_filepath = realpath( dirname(__FILE__).'/../../../../web/'.$file->getLocalFileName() );
                 if (!$local_filepath) {
-                    // File doesn't exist on server for some reason
-                    parent::decryptObject($file_id, 'file');
+                    // File is public, but doesn't exist in decrypted format for some reason
+                    $local_filepath = parent::decryptObject($file_id, 'file');
                 }
                 else if ( filesize($local_filepath) < $file->getFilesize() ) {
                     // File exists but isn't fully decrypted yet for some reason...it's most likely in the process of being decrypted

--- a/src/ODR/AdminBundle/Controller/WorkerController.php
+++ b/src/ODR/AdminBundle/Controller/WorkerController.php
@@ -809,10 +809,10 @@ $ret .= '  Set current to '.$count."\n";
                 $base_obj->setLocalFileName($destination_filename);
 
                 // Encryption of a given file/image is simple...
-                self::encryptObject($object_id, $object_type);
+                parent::encryptObject($object_id, $object_type);
 
                 // Calculate/store the checksum of the file to indicate the encryption process is complete
-                $filepath = self::decryptObject($object_id, $object_type);
+                $filepath = parent::decryptObject($object_id, $object_type);
                 $original_checksum = md5_file($filepath);
                 $base_obj->setOriginalChecksum($original_checksum);
 

--- a/src/ODR/AdminBundle/Controller/WorkerController.php
+++ b/src/ODR/AdminBundle/Controller/WorkerController.php
@@ -745,7 +745,7 @@ $ret .= '  Set current to '.$count."\n";
      *
      * @return Response TODO
      */
-    public function cryptoRequestAction(Request $request)
+    public function cryptorequestAction(Request $request)
     {
         $return = array();
         $return['r'] = 0;
@@ -782,25 +782,24 @@ $ret .= '  Set current to '.$count."\n";
 
 
             // ----------------------------------------
-            // Locate the directory with the encrypted file chunks
-            $base_obj = null;
-            if ($object_type == 'file') {
-                $crypto_dir .= 'File_'.$object_id;
-                $base_obj = $em->getRepository('ODRAdminBundle:File')->find($object_id);
-            }
-            /*
-            else if ($object_type == 'image') {
-                $crypto_dir .= 'Image_'.$object_id;
-                $base_obj = $em->getRepository('ODRAdminBundle:Image')->find($object_id);
-            }
-            */
-
-            if ($base_obj == null)
-                throw new \Exception('Invalid Form');
-
-
-            // ----------------------------------------
             if ($crypto_type == 'encrypt') {
+
+                // ----------------------------------------
+                // Locate the directory with the encrypted file chunks
+                $base_obj = null;
+                if ($object_type == 'file') {
+                    $crypto_dir .= 'File_'.$object_id;
+                    $base_obj = $em->getRepository('ODRAdminBundle:File')->find($object_id);
+                }
+/*
+                else if ($object_type == 'image') {
+                    $crypto_dir .= 'Image_'.$object_id;
+                    $base_obj = $em->getRepository('ODRAdminBundle:Image')->find($object_id);
+                }
+*/
+                if ($base_obj == null)
+                    throw new \Exception('Invalid Form');
+
                 // Move file from completed directory to decrypted directory in preparation for encryption...
                 $destination_path = dirname(__FILE__).'/../../../../web';
                 $destination_filename = $base_obj->getUploadDir().'/File_'.$object_id.'.'.$base_obj->getExt();
@@ -855,22 +854,41 @@ $ret .= '  Set current to '.$count."\n";
 
                 // Don't need to do anything else
 */
+/*
+                $obj = null;
+                if ( strtolower($object_type) == 'file')
+                    $obj = $em->getRepository('ODRAdminBundle:File')->find($object_id);
+                else if ( strtolower($object_type) == 'image')
+                    $obj = $em->getRepository('ODRAdminBundle:Image')->find($object_id);
+                else
+                    throw new \Exception('Invalid Form, got "'.strtolower($object_type).'"');
 
-                // TEMP - decrypt files, calculate and store their decrypted filesize in the database, then delete them
-                $file = $em->getRepository('ODRAdminBundle:File')->find($object_id);
-                if ($file == null)
-                    throw new \Exception('Deleted File');
+                if ($obj == null)
+                    throw new \Exception('Deleted '.$object_type);
+
 
                 $absolute_path = parent::decryptObject($object_id, $object_type);
 
-                clearstatcache(true, $absolute_path);
-                $filesize = filesize($absolute_path);
+                if ( strtolower($object_type) == 'file') {
+                    clearstatcache(true, $absolute_path);
+                    $filesize = filesize($absolute_path);
+                    $checksum = md5_file($absolute_path);
 
-                $file->setFilesize($filesize);
-                $em->persist($file);
-                $em->flush();
+                    $obj->setFilesize($filesize);
+                    $obj->setOriginalChecksum($checksum);
+                    $em->persist($obj);
+                    $em->flush();
+                }
+                else if ( strtolower($object_type) == 'image') {
+                    $checksum = md5_file($absolute_path);
+
+                    $obj->setOriginalChecksum($checksum);
+                    $em->persist($obj);
+                    $em->flush();
+                }
 
                 unlink($absolute_path);
+*/
             }
 
         }
@@ -1406,16 +1424,26 @@ print '</pre>';
 
             if ($object_type == 'file' || $object_type == 'File')
                 $object_type = 'File';
-//            else if ($object_type == 'image' || $object_type == 'Image')
-//                $object_type = 'Image';
+            else if ($object_type == 'image' || $object_type == 'Image')
+                $object_type = 'Image';
             else
                 return null;
 
-            $query = $em->createQuery(
-                'SELECT e
-            FROM ODRAdminBundle:'.$object_type.' AS e
-            WHERE e.deletedAt IS NULL'
-            );
+            $query = null;
+            if ($object_type == 'File') {
+                $query = $em->createQuery(
+                    'SELECT e.id
+                    FROM ODRAdminBundle:'.$object_type.' AS e
+                    WHERE e.deletedAt IS NULL AND (e.original_checksum IS NULL OR e.filesize = 0)'
+                );
+            }
+            else if ($object_type == 'Image') {
+                $query = $em->createQuery(
+                    'SELECT e.id
+                    FROM ODRAdminBundle:'.$object_type.' AS e
+                    WHERE e.deletedAt IS NULL AND e.original_checksum IS NULL'
+                );
+            }
             $results = $query->getResult();
 
             $object_type = strtolower($object_type);
@@ -1425,7 +1453,7 @@ print '</pre>';
                 $payload = json_encode(
                     array(
                         "object_type" => $object_type,
-                        "object_id" => $file->getId(),
+                        "object_id" => $file['id'],
                         "target_filepath" => '',
                         "crypto_type" => 'decrypt',
                         "memcached_prefix" => $memcached_prefix,    // debug purposes only

--- a/src/ODR/AdminBundle/Controller/XMLController.php
+++ b/src/ODR/AdminBundle/Controller/XMLController.php
@@ -1494,11 +1494,12 @@ $write = false;
             // Grab necessary objects
             $user = $repo_user->find($user_id);
             $drf = $repo_datarecordfield->find($drf_id);
-            $storage_path = dirname(__FILE__).'/../../../../web/uploads/xml/user_'.$user_id.'/storage/';
+            $path_prefix = dirname(__FILE__).'/../../../../web/';
+            $storage_path = 'uploads/xml/user_'.$user_id.'/storage/';
 
             // Ensure storage directory exists
-            if ( !file_exists($storage_path) )
-                mkdir( $storage_path );
+            if ( !file_exists($path_prefix.$storage_path) )
+                mkdir( $path_prefix.$storage_path );
 
             $my_obj = null;
             if ($object_type == 'File')
@@ -1514,7 +1515,7 @@ $write = false;
             $file_contents = null;
             if ($href == '') {
                 // File/Image already exists on server
-                $file_contents = file_get_contents($storage_path.$original_name);
+                $file_contents = file_get_contents($path_prefix.$storage_path.$original_name);
             }
             else {
                 // Grab the file from a remote server using cURL...
@@ -1552,7 +1553,7 @@ $write = false;
                 }
                 else {
                     // For convenience, temporarily save the file in the xml storage directory
-                    $handle = fopen($storage_path.$original_name, 'w');
+                    $handle = fopen($path_prefix.$storage_path.$original_name, 'w');
                     if ($handle == false)
                         throw new \Exception('Could not save downloaded file to storage directory');
 
@@ -1580,16 +1581,16 @@ if ($write) {
                 $ret .= '>> '.$object_type.' is an exact copy of existing version, skipping...'."\n";
 
                 // Delete the file/image from the server since it already officially exists
-                unlink($storage_path.$original_name);
+                unlink($path_prefix.$storage_path.$original_name);
             }
             else {
                 // ...need to "update" the existing file/image
                 $ret .= '>> '.$object_type.' is different than uploaded version...';
 
                 // Determine the path to the current file/image
-                $local_filepath = dirname(__FILE__).'/../../../../web/uploads/files/File_';
+                $local_filepath = $path_prefix.'uploads/files/File_';
                 if ($object_type == 'Image')
-                    $local_filepath = dirname(__FILE__).'/../../../../web/uploads/images/Image_';
+                    $local_filepath = $path_prefix.'uploads/images/Image_';
                 $local_filepath .= $my_obj->getId().'.'.$my_obj->getExt();
 
 if ($write) {
@@ -1602,7 +1603,7 @@ if ($write) {
                 fclose($handle);
 
                 // Delete the uploaded file/image from the storage directory
-                unlink($storage_path.$original_name);
+                unlink($path_prefix.$storage_path.$original_name);
                 $ret .= 'overwritten...';
 
                 // Update other properties of the file/image that got changed

--- a/src/ODR/AdminBundle/Resources/config/routing.yml
+++ b/src/ODR/AdminBundle/Resources/config/routing.yml
@@ -603,6 +603,13 @@ odr_record_delete_image:
     requirements:
         image_id:  \d+
 
+odr_record_rotate_image:
+    pattern:  /edit/record/rotateimage/{image_id}/{direction}
+    defaults: { _controller: ODRAdminBundle:Record:rotateimage }
+    requirements:
+        image_id:  \d+
+        direction: -1|1
+
 odr_record_save_image_order:
     pattern:  /edit/record/saveimageorder
     defaults: { _controller: ODRAdminBundle:Record:saveimageorder }
@@ -665,7 +672,6 @@ odr_image_download:
     defaults: { _controller: ODRAdminBundle:Results:imagedownload }
     requirements:
         image_id:  \d+
-
 
 
 #-----------------------------------------

--- a/src/ODR/AdminBundle/Resources/config/routing.yml
+++ b/src/ODR/AdminBundle/Resources/config/routing.yml
@@ -919,7 +919,7 @@ odr_csv_link_worker:
 #-----------------------------------------
 # Flow Controller
 odr_flow_upload:
-    pattern: /edit/csv_import/flow/{upload_type}/{datatype_id}/{datarecordfield_id}
+    pattern: /edit/flow/{upload_type}/{datatype_id}/{datarecordfield_id}
     defaults: { _controller: ODRAdminBundle:Flow:flow, datarecordfield_id: '' }
     requirements:
         upload_type: 'xml|csv|file|image|csv_import_file_storage|xml_import_file_storage'

--- a/src/ODR/AdminBundle/Resources/config/services.yml
+++ b/src/ODR/AdminBundle/Resources/config/services.yml
@@ -2,19 +2,19 @@ parameters:
     file_validation:
         xml:
             maxSize: 100   # maximum allowed filesize (in Mb) for this type of uploaded file
-            maxSizeErrorMessage: The uploaded file is too large.  Allowed maximum size is 100 MB.
+            maxSizeErrorMessage: The uploaded xml file is too large.  Allowed maximum size is 100 MB.
             mimeTypes: [ text/xml ]
             mimeTypesErrorMessage: Please upload a valid XML file.
 
         csv:
             maxSize: 100   # maximum allowed filesize (in Mb) for this type of uploaded file
-            maxSizeErrorMessage: The uploaded file is too large.  Allowed maximum size is 100 MB.
+            maxSizeErrorMessage: The uploaded csv file is too large.  Allowed maximum size is 100 MB.
             mimeTypes: [ ]
             mimeTypesErrorMessage: Please upload a valid CSV file.
 
         image:
             maxSize: 100   # maximum allowed filesize (in Mb) for this type of uploaded file
-            maxSizeErrorMessage: The uploaded file is too large.  Allowed maximum size is 100 MB.
+            maxSizeErrorMessage: The uploaded image is too large.  Allowed maximum size is 100 MB.
             mimeTypes: [ application/pdf, application/x-pdf, image/jpeg, image/jpg, image/png, image/gif ]
             mimeTypesErrorMessage: Please upload a valid PDF, GIF, JPG or PNG file.
 

--- a/src/ODR/AdminBundle/Resources/views/Datatype/type_list_content_design.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Datatype/type_list_content_design.html.twig
@@ -206,8 +206,7 @@
                 success: function(data, textStatus, jqXHR) {
                     if(data.r == 0) {
                         // Reload this area of the page
-//                        LoadContentFullAjax('{{ path('odr_list_types', { 'section': 'design' }) }}');
-                        window.location.reload(true);
+                        window.location.replace( "{{ path('odr_admin_homepage') }}" + "#" + "{{ path('odr_list_types', { 'section': 'design' }) }}" );
                     }
                     else {
                         // Error occurred

--- a/src/ODR/AdminBundle/Resources/views/Default/file_handling.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Default/file_handling.html.twig
@@ -8,7 +8,7 @@
         });
     });
 
-    function handleFileDownload(event, file_id, href, short_form) {
+    function handleFileDownload(event, file_id, href, short_form, can_cancel) {
         // Prevent a normal file download
         event.preventDefault();
         // If using ShortResults, this click will trigger a load of the datarecord this file belongs to...prevent that
@@ -42,15 +42,21 @@ console.log(file_decrypt_timeouts);
                 // Store that a decryption for this file is in progress...
                 pending_file_decryptions[ file_id ] = download;
 
-                // Activate the cancel button for this file decryption...
-                $(cancel_button).unbind('click');
-                $(cancel_button).click(function(event) {
-                    // If using ShortResults, this click will trigger a load of the datarecord this file belongs to...prevent that
-                    if (short_form)
-                        event.stopImmediatePropagation();
+                if (can_cancel) {
+                    // Activate the cancel button for this file decryption...
+                    $(cancel_button).unbind('click');
+                    $(cancel_button).click(function (event) {
+                        // If using ShortResults, this click will trigger a load of the datarecord this file belongs to...prevent that
+                        if (short_form)
+                            event.stopImmediatePropagation();
 
-                    cancelFileDecryption(download, file_id);
-                });
+                        cancelFileDecryption(download, file_id);
+                    });
+                }
+                else {
+                    // Not allowed to cancel this decryption, hide the button
+                    $(cancel_button).hide();
+                }
             },
             successCallback: function (url) {
 //console.log('success for file ' + file_id);
@@ -59,6 +65,7 @@ console.log(file_decrypt_timeouts);
                 file_decrypt_timeouts[ file_id ] = null;
 
                 // Download is done, No longer need these
+                $(cancel_button).show();
                 $(download_div).hide();
                 $(cancel_button).unbind('click');
             },
@@ -69,6 +76,7 @@ console.log(file_decrypt_timeouts);
                 file_decrypt_timeouts[ file_id ] = null;
 
                 // Download is done, No longer need these
+                $(cancel_button).show();
                 $(download_div).hide();
                 $(cancel_button).unbind('click');
             }
@@ -142,6 +150,10 @@ console.log(file_decrypt_timeouts);
                                 value: current_value,
                                 max: max_value
                             });
+
+                            // If file got decrypted, stop querying server for progress
+                            if (current_value == 100)
+                                file_decrypt_timeouts[ file_id ] = null;
                         }
                     }
 

--- a/src/ODR/AdminBundle/Resources/views/Flow/flow_common.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Flow/flow_common.html.twig
@@ -4,7 +4,7 @@
     // Called by a flow.js instance when a file is slated for upload
     function ODRFileUpload_filesAdded(files, event, target) {
         // Hide any current progress bars
-        $("#ODRFileUploadProgress_" + target).html('');
+        //$("#ODRFileUploadProgress_" + target).html('');
 
         // Create a progress bar div for each of the files...
         $.each(files, function(index, file) {
@@ -16,7 +16,8 @@
             $("#ODRFileUploadProgress_" + target).append(html);
 
             // Attach a cancel handler for this file
-            $("#ODRFileUploadProgress_" + target + " .ODRFileUploadCancel").on('click', function() {
+            $("#" + id + " > .ODRFileUploadCancel").unbind('click');
+            $("#" + id + " > .ODRFileUploadCancel").on('click', function() {
                 // Abort uploading this file
                 file.cancel();
 
@@ -26,9 +27,12 @@
                     $(this).parent().remove();
                 }
 
+                // Remove this progress div since the user cancelled the upload
+                $("#" + id).remove();
+
                 // Re-enable file upload on cancel
-                $("#ODRFileUpload_" + target + " input").removeAttr('disabled');
-                $("#ODRFileUpload_" + target + " .ODRUploadBlurb").show();
+                //$("#ODRFileUpload_" + target + " input").removeAttr('disabled');
+                //$("#ODRFileUpload_" + target + " .ODRUploadBlurb").show();
 
                 // TODO - Notify server to delete all chunks of this file?                
             });

--- a/src/ODR/AdminBundle/Resources/views/Flow/flow_upload.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Flow/flow_upload.html.twig
@@ -1,9 +1,21 @@
 {% spaceless %}
 
+{# Reduce confusion with the upload button... #}
+{% set upload_text = '' %}
+{% if upload_type == 'file' or upload_type == 'csv_import_file_storage' or upload_type == 'xml_import_file_storage' %}
+    {% set upload_text = 'Files' %}
+{% elseif upload_type == 'image' %}
+    {% set upload_text = 'Images' %}
+{% elseif upload_type == 'csv' %}
+    {% set upload_text = 'CSV File' %}
+{% elseif upload_type == 'xml' %}
+    {% set upload_text = 'XML File' %}
+{% endif %}
+
 <div id="ODRFileUpload_{{ target }}" class="ODRFileUpload">
     <span class="ODRUploadBlurb">
         <span class="pure-button pure-button-primary">
-            Upload Files
+            Upload {{ upload_text }}
         </span>
         <b>OR</b> Drag and Drop here
     </span>
@@ -12,7 +24,7 @@
 <div id="ODRFileUploadProgress_{{ target }}" class="ODRFileUploadProgress"></div>
 
 <style>
-    .foo {
+    .ODRUploadDragHighlight {
         background: #00FF00;
     }
     .ODRFileUploadProgress {
@@ -35,6 +47,8 @@
 
     var flow_{{ target }} = null;
     var flow_errors_{{ target }} = false;
+    var flow_cancelled_{{ target }} = false;
+
     $(function() {
 
         // TODO - drag CSS needs work
@@ -43,7 +57,7 @@
             event.stopPropagation();
             event.preventDefault();
 
-            $(this).addClass('foo');
+            $(this).addClass('ODRUploadDragHighlight');
         });
 
         $("#ODRFileUpload_{{ target }}").off('dragleave');
@@ -51,18 +65,20 @@
             event.stopPropagation();
             event.preventDefault();
 
-            $(this).removeClass('foo');
+            $(this).removeClass('ODRUploadDragHighlight');
         });
 
         $("#ODRFileUpload_{{ target }}").off('dragover');
         $("#ODRFileUpload_{{ target }}").on('dragover', function(event) {
             event.stopPropagation();
             event.preventDefault();
+
+            $(this).addClass('ODRUploadDragHighlight');
         });
 
         $("#ODRFileUpload_{{ target }}").off('drop');
         $("#ODRFileUpload_{{ target }}").on('drop', function(event) {
-            $(this).removeClass('foo');
+            $(this).removeClass('ODRUploadDragHighlight');
         });
 
         // Create a new Flow.js instance
@@ -70,6 +86,7 @@
             "target": "{{ path('odr_flow_upload', {'upload_type': upload_type, 'datatype_id': datatype_id, 'datarecordfield_id': datarecordfield_id}) }}",
             "chunkSize": 2 * 1024 * 1024,
             "forceChunkSize": true,
+//            "simultaneousUploads": 3,
 
             "chunkRetryInterval": 1000,
             "maxChunkRetries": 3,
@@ -92,16 +109,23 @@
 
         // This event is fired when a group of files are added to the file control
         flow_{{ target }}.on('filesAdded', function(files, event) {
-//console.log('added: ' + files);
+/*
+console.log('added: ');
+console.log(files);
+*/
             ODRFileUpload_filesAdded(files, event, "{{ target }}");
         });
 
 
         // Automatically upload files after submission
         flow_{{ target }}.on('filesSubmitted', function(files, event) {
-//console.log('submitted: ' + files);
+/*
+console.log('submitted: ');
+console.log(files);
+*/
             ODRFileUpload_filesSubmitted(flow_{{ target }});
             flow_errors_{{ target }} = false;
+            flow_cancelled_{{ target }} = false;
 
 {% if single_file == true %}
             // Block uploads any further uploads after a single file
@@ -117,16 +141,24 @@
             ODRFileUpload_fileProgress(file, chunk, "{{ target }}");
         });
 
-{#
-        // TODO - other stuff to do on successes?
-        flow_{{ target }}.on('fileSuccess', function(file, message) {
-console.log('success: ' + file);
-        });
-#}
 
-        // Display any errors encountered during the upload of a file
+        // This event is fired when a single file finishes uploading
+        flow_{{ target }}.on('fileSuccess', function(file, message, chunk) {
+/*
+console.log('success: ');
+console.log(file);
+*/
+            // File got uploaded...preserve name and progress bar, but remove cancel button
+            $("#" + file.uniqueIdentifier + "_{{ target }} > .ODRFileUploadCancel").remove();
+        });
+
+
+        // This event is fired when the upload of any file runs into an error
         flow_{{ target }}.on('fileError', function(file, message) {
-//console.log('error: ' + file);
+/*
+console.log('error: ');
+console.log(file);
+*/
             // Display error and stop upload
             ODRFileUpload_fileError(file, message, "{{ target }}");
             file.cancel();
@@ -140,23 +172,25 @@ console.log('success: ' + file);
         });
 
 
-        // Perform tasks when all files finish uploading
+        // This event is fired when all files finish uploading
         flow_{{ target }}.on('complete', function() {
 //console.log('complete');
             // All uploads complete, remove all files from the HTML5 File API so they can get re-uploaded
             flow_{{ target }}.cancel();
 
-            if ( flow_errors_{{ target }} == false ) {
-                {{ callback }}
+            if ( flow_errors_{{ target }} == false && flow_cancelled_{{ target }} == false ) {
+                // Attempt to ensure this only executes once
+                flow_cancelled_{{ target }} = true;
 
                 // TODO - make this an option?
-                $(".ODRFileUploadProgressDiv").hide();
-                $(".ODRFileUploadProgressDiv").remove();
+                // All files finished uploading...remove all progress bars
+                $("#ODRFileUploadProgress_{{ target }}").html('');
+
+                {{ callback }}
             }
         });
 
     });
-
 </script>
 
 {% endspaceless %}

--- a/src/ODR/AdminBundle/Resources/views/MassEdit/massedit_ajax.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/MassEdit/massedit_ajax.html.twig
@@ -101,7 +101,7 @@ $(function() {
 
 function initPage() {
 
-    // Hide all TEDs without input fields
+    // Hide all theme elements without input fields
     $(".ODRThemeElement").each(function() {
         var found = false;
         $(this).find("input").each(function() {
@@ -122,7 +122,7 @@ function initPage() {
         // Apply dimensions of parent div to loading div
         $(this).css({"height": height, "line-height": height, "width": width});
 
-        $(this).attr('title', "This Datafield is marked as unique, and therefore can't be mass updated...multiple Datarecords would have the same value if that happened.");
+        $(this).attr('title', "This Datafield is marked as unique, and therefore can't be mass updated...multiple Datarecords would have the same value afterwards.");
     });
 
     $(".ODRDatePicker").datepicker({
@@ -142,10 +142,7 @@ function initPage() {
     $(".ODRDatePicker_clear").unbind('click');
     $(".ODRDatePicker_clear").click(function() {
         $(this).parent().parent().find(".ODRDatePicker").datepicker('setDate', null);
-//        var form_id = $(this).parent().parent().parent().parent().attr('id');
-//        SaveRecordData('#' + form_id, '');
     });
-
 }
 
 function doMassUpdate() {
@@ -181,6 +178,23 @@ function doMassUpdate() {
         }
     });
 
+    // Files/Images
+    $(".ODRFile").each(function() {
+        // Grab the ID of the field
+        var datafield_id_data = $(this).attr('id').split('_');
+        var datafield_id = datafield_id_data[1];
+
+        // Remove any value for this datafield currently stored in the form
+        if ( $("#Value_" + datafield_id) !== null )
+            $("#Value_" + datafield_id).remove();
+
+        // Save any value currently in this datafield
+        var val = $(this).val();
+        if (val !== '' && val !== '0') {
+            var element = $("<input>", {id: "Value_" + datafield_id, class: "massedit_form_input", type: "hidden", value: val, name: "datafields[" + datafield_id + "]"});
+            $("#massedit_form").append(element);
+        }
+    });
 
     // Single Selects
     $(".ODRSingleSelect").each(function() {
@@ -313,6 +327,8 @@ function doMassUpdate() {
 
     var data = $("#massedit_form").serialize();
     var url = $("#massedit_form").attr('action');
+
+//    console.log( $("#massedit_form") );
 //alert(url);
 //return;
 

--- a/src/ODR/AdminBundle/Resources/views/MassEdit/massedit_ajax.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/MassEdit/massedit_ajax.html.twig
@@ -1,9 +1,18 @@
 {% spaceless %}
 
 {% set datatype = datatype_tree.datatype %}
-<h1 class="grid_12 no-margin-top-phone">
-    <span>Mass Update &raquo; {{ datatype.shortname }}</span>
-</h1>
+<div class="grid_12 no-margin-top-phone">
+    <h1 style="display: inline;">
+        <span>Mass Update &raquo; {{ datatype.shortname }}</span>
+    </h1>
+    <span>
+        <select class="ODRPublicSelect" style="margin-left: 15px;" rel="{{ datatype.id }}">
+            <option value="-1">Make all Datarecords non-public</option>
+            <option value="0" selected>Don't change public status</option>
+            <option value="1">Make all Datarecords public</option>
+        </select>
+    </span>
+</div>
 
 <form id="massedit_form" style="display:none;" action="{{ path('odr_mass_update_start') }}">
     <input type="hidden" value="{{ odr_tab_id }}" name="odr_tab_id"/>
@@ -11,17 +20,10 @@
 </form>
 
 <div>
-    <select id="public_select" class="SelectGroup">
-        <option value="-1">Make all Datarecords non-public</option>
-        <option value="0" selected>Don't change public status</option>
-        <option value="1">Make all Datarecords public</option>
-    </select>
-    </br></br>
-</div>
-
-<div>
     <button class="pure-button pure-button-primary" type="button" onclick="doMassUpdate();">Save Changes</button>
 </div>
+
+</br></br>
 
 {% include 'ODRAdminBundle:MassEdit:massedit_area.html.twig' with {'datatype_tree': datatype_tree, 'datafield_permissions': datafield_permissions} %}
 
@@ -154,11 +156,21 @@ function doMassUpdate() {
     $(".massedit_form_input").remove();
 
     // Public status
-    var val = $("#public_select").val();
-    if (val == '-1' || val == '1') {
-        var element = $("<input>", {id: "Value_public", class: "massedit_form_input", type: "hidden", value: val, name: "datarecord_public"});
-        $("#massedit_form").append(element);
-    }
+    $(".ODRPublicSelect").each(function() {
+        // Grab the ID of the datatype
+        var datatype_id = $(this).attr('rel');
+
+        // Remove any value for this field currently stored in the form
+        if ( $("#PublicStatus_" + datatype_id) !== null )
+            $("#PublicStatus_" + datatype_id).remove();
+
+        // Save any value currently in this field
+        var val = $(this).val();
+        if (val == '-1' || val == '1') {
+            var element = $("<input>", {id: "PublicStatus_" + datatype_id, class: "massedit_form_input", type: "hidden", value: val, name: "public_status[" + datatype_id + "]"});
+            $("#massedit_form").append(element);
+        }
+    });
 
     // Checkboxes
     $(".ODRBoolean").each(function() {
@@ -290,7 +302,7 @@ function doMassUpdate() {
             $("#Value_" + datafield_id).remove();
 
         // Save any value currently in this datafield
-        var val = $(this).html().trim();
+        var val = $(this).val().trim();
         if (val !== '') {
             var element = $("<input>", {id: "Value_" + datafield_id, class: "massedit_form_input", type: "hidden", value: val, name: "datafields[" + datafield_id + "]"});
             $("#massedit_form").append(element);

--- a/src/ODR/AdminBundle/Resources/views/MassEdit/massedit_childtype.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/MassEdit/massedit_childtype.html.twig
@@ -7,14 +7,13 @@
 
     {% if datatype_tree.top_level == 0 %}
         {# current datatype is a child or linked datatype #}
-{#
         <h3 class="ui-accordion-header ui-helper-reset ui-state-default ui-state-active ui-corner-top" role="tab" aria-expanded="true" aria-selected="true" tabindex="0">
             <span class="ui-icon ui-icon-triangle-1-s"></span>
             <a id="Datatype_{{ datatype.id }}_ShortName">{{ datatype.shortname }}</a>
 
-            {% include 'ODRAdminBundle:Displaytemplate:design_area_datatypetools_div.html.twig' with {'datatype_tree': datatype_tree, 'datatype': datatype} %}
+            {#{% include 'ODRAdminBundle:Displaytemplate:design_area_datatypetools_div.html.twig' with {'datatype_tree': datatype_tree, 'datatype': datatype} %}#}
         </h3>
-#}
+
         <div class="ODRFieldArea accordion-content pure-u-1" id="FieldArea_{{ datatype.id }}">
             {% include 'ODRAdminBundle:MassEdit:massedit_fieldarea.html.twig' with {'datatype_tree': datatype_tree, 'datafield_permissions': datafield_permissions} %}
         </div><!-- End of #FieldArea_{{ datatype.id }} -->
@@ -23,11 +22,11 @@
         {# current datatype is top-level #}
 {#
         {% include 'ODRAdminBundle:Displaytemplate:design_area_datatypetools_div.html.twig' with {'datatype_tree': datatype_tree, 'datatype': datatype} %}
-
         <div class="header">
             <h3 id="Datatype_{{ datatype.id }}_ShortName">{{ datatype.shortname }}</h3>
         </div>
 #}
+
         <div class="ODRFieldArea pure-u-1" id="FieldArea_{{ datatype.id }}">
             {% include 'ODRAdminBundle:MassEdit:massedit_fieldarea.html.twig' with {'datatype_tree': datatype_tree, 'datafield_permissions': datafield_permissions} %}
         </div><!-- End of #FieldArea_{{ datatype.id }} -->

--- a/src/ODR/AdminBundle/Resources/views/MassEdit/massedit_childtype.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/MassEdit/massedit_childtype.html.twig
@@ -10,8 +10,11 @@
         <h3 class="ui-accordion-header ui-helper-reset ui-state-default ui-state-active ui-corner-top" role="tab" aria-expanded="true" aria-selected="true" tabindex="0">
             <span class="ui-icon ui-icon-triangle-1-s"></span>
             <a id="Datatype_{{ datatype.id }}_ShortName">{{ datatype.shortname }}</a>
-
-            {#{% include 'ODRAdminBundle:Displaytemplate:design_area_datatypetools_div.html.twig' with {'datatype_tree': datatype_tree, 'datatype': datatype} %}#}
+            <select class="ODRPublicSelect" style="margin-left: 15px;" rel="{{ datatype.id }}">
+                <option value="-1">Make all Datarecords non-public</option>
+                <option value="0" selected>Don't change public status</option>
+                <option value="1">Make all Datarecords public</option>
+            </select>
         </h3>
 
         <div class="ODRFieldArea accordion-content pure-u-1" id="FieldArea_{{ datatype.id }}">
@@ -21,7 +24,6 @@
     {% else %}
         {# current datatype is top-level #}
 {#
-        {% include 'ODRAdminBundle:Displaytemplate:design_area_datatypetools_div.html.twig' with {'datatype_tree': datatype_tree, 'datatype': datatype} %}
         <div class="header">
             <h3 id="Datatype_{{ datatype.id }}_ShortName">{{ datatype.shortname }}</h3>
         </div>

--- a/src/ODR/AdminBundle/Resources/views/MassEdit/massedit_datafield.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/MassEdit/massedit_datafield.html.twig
@@ -30,51 +30,30 @@
         </select>
     </fieldset>
 
-
-{#
     {% elseif field_typename == "File" %}
     <fieldset>
+        <label id="Label_{{ field.id }}" class="ODRFieldLabel pure-u-1" title="{{ field.description }}">{{ field.fieldname }}</label>
         <div class="pure-u-1">
-            <table class="ODRTable pure-u-1">
-                <thead class="pure-u-1">
-                    <tr class="pure-u-1">
-                        <th class="pure-u-1-24">&nbsp;</th>
-                        <th class="pure-u-20-24">{{ field.fieldname }}</th>
-                        <th class="pure-u-3-24">Options</th>
-                    </tr>
-                </thead>
-                <tbody class="pure-u-1">
-                    <tr class="pure-u-1">
-                        <td class="pure-u-1-24">&nbsp;</td>
-                        <td class="pure-u-20-24">file_name_here</td>
-                        <td class="pure-u-3-24">
-                            <i class="Cursor tooltip fa fa-globe fa-lg ODRPublicFile" title="Public since [YYYY-MM-DD]"></i>
-                            <i class="Cursor tooltip fa fa-calendar fa-lg" title="Uploaded [YYYY-MM-DD] by John Doe"></i>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <div class="pure-u-1">
-            <div class="pure-u-1-24"></div>
-            <div class="pure-u-23-24">
-                <input disabled id="Input_{{ field.id }}" type="file" id="f6_file" name="f6_file"/>
-            </div>
+            <select id="SelectGroup_{{ field.id }}" class="ODRFile">
+                <option value="-1">Make all Files non-public</option>
+                <option value="0" selected>Don't change public status</option>
+                <option value="1">Make all Files public</option>
+            </select>
         </div>
     </fieldset>
-#}
-{#
+
     {% elseif field_typename == "Image" %}
     <fieldset>
         <label id="Label_{{ field.id }}" class="ODRFieldLabel pure-u-1" title="{{ field.description }}">{{ field.fieldname }}</label>
         <div class="pure-u-1">
-            <div class="pure-u-1">&nbsp;<i class="ODRDeleteImage Pointer fa fa-lg fa-trash-o" title="Delete Image"></i>&nbsp;<i class="PublicImage Pointer fa fa-lg fa-globe"></i>&nbsp;</div>
-            <div class="pure-u-1">
-                <img class="pure-img" src="/img/_demo/_tmb/1.jpg" />
-            </div>
+            <select id="SelectGroup_{{ field.id }}" class="ODRFile">
+                <option value="-1">Make all Images non-public</option>
+                <option value="0" selected>Don't change public status</option>
+                <option value="1">Make all Images public</option>
+            </select>
         </div>
     </fieldset>
-#}
+
     {% elseif field_typename == "Paragraph Text" %}
     <fieldset>
         <label id="Label_{{ field.id }}" for="Input_{{ field.id }}" class="ODRFieldLabel">{{ field.fieldname }}</label>

--- a/src/ODR/AdminBundle/Resources/views/MassEdit/massedit_fieldarea.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/MassEdit/massedit_fieldarea.html.twig
@@ -6,37 +6,16 @@
 
     {% set element = data.theme_element %}
     {# inverse of "if datatype_tree.is_link == 1 and element.displayinresults == 0" #}
-    {% if datatype_tree.is_link == 0 or element.displayinresults == 1 %}
+    {#{% if datatype_tree.is_link == 0 or element.displayinresults == 1 %}#}
+    {% if datatype_tree.is_link == 0 %}
         <div id="ThemeElement_{{ element.id }}" class="ODRThemeElement pure-u-1 pure-u-md-{{ element.getcsswidthmed }} pure-u-xl-{{ element.getcsswidthxl }}">
             <div class="ODRInnerBox">
-{#
-            {% if datatype_tree.is_link == 0 %}
-
-            <div id="ThemeElementTools_{{ element.id }}" class="DataTypeTools pure-u-1"><span style="float:right;">
-                <i class="Pointer tooltip fa fa-info-circle ODRThemeElementProperties" title="ThemeElement Properties" rel="{{ element.id }}"></i>
-                <i class="Pointer tooltip fa {% if element.displayinresults == 1 %}fa-eye{% else %}fa-eye-slash{% endif %} ODRThemeElementVisible" title="ThemeElement{% if element.displayinresults == 0 %} not{% endif %} visible to public" rel="{{ element.id }}"></i>
-
-                <i class="Pointer tooltip fa fa-plus-square {% if data.datatype != null %}fa-muted{% endif %} ODRAddDatafield" title="Add DataField" rel="{{ datatype.id }}"></i>
-                <i class="Pointer tooltip fa fa-list-alt {% if data.datatype != null or data.datafields != null %}fa-muted{% endif %} ODRAddChildtype" title="Add Child Type" rel="{{ datatype.id }}"></i>
-
-                {% if data.datafields != null or (data.datatype != null and data.datatype.is_link == 0) %}
-                    <i class="Pointer tooltip fa fa-link fa-muted ODRLinkDatatype" title="Link DataType" rel="{{ datatype.id }}"></i>
-                {% elseif data.datatype != null and data.datatype.is_link == 1 %}
-                    <i class="Pointer tooltip fa fa-link ODRActiveIcon ODRLinkDatatype" title="Link DataType" rel="{{ datatype.id }}"></i>
-                {% else %}
-                    <i class="Pointer tooltip fa fa-link ODRLinkDatatype" title="Link DataType" rel="{{ datatype.id }}"></i>
-                {% endif %}
-
-                <i class="Pointer tooltip fa fa-trash-o {% if data.datafields != null or data.datatype != null %}fa-muted{% endif %} ODRDeleteThemeElement" title="Delete ThemeElement" rel="{{ element.id }}"></i>
-            </span></div>
-
-            {% endif %}
-#}
     {% endif %}
 
 
-    {% if datatype_tree.is_link == 1 and element.displayinresults == 0 %}
-        {# don't render hidden theme_elements off linked types? #}
+    {#{% if datatype_tree.is_link == 1 and element.displayinresults == 0 %}#}
+    {% if datatype_tree.is_link == 1 %}
+        {# don't render theme_elements off linked types #}
     {% elseif data.datafields != null %}
         {# render all datafields in this theme element #}
         {% for datafield in data.datafields %}
@@ -56,32 +35,31 @@
 
             {% set field_typename = datafield.fieldtype.typename %}
 
-            {% if field_typename != "File" and field_typename != "Image" %}
-                <div class="ODRDataField pure-u-1 pure-u-md-{{ theme_datafield.getcsswidthmed }} pure-u-xl-{{ theme_datafield.getcsswidthxl }}" id="Field_{{ datafield.id }}" >
+            <div class="ODRDataField pure-u-1 pure-u-md-{{ theme_datafield.getcsswidthmed }} pure-u-xl-{{ theme_datafield.getcsswidthxl }}" id="Field_{{ datafield.id }}" >
     
-                {% if field_typename == "Markdown" %}
-                    {% include 'ODRAdminBundle:Results:results_markdown.html.twig' with {'field': datafield} %}
-                {% elseif can_view_datafield == 1 %}
-                    {% include 'ODRAdminBundle:MassEdit:massedit_datafield.html.twig' with {'fieldtheme': theme_datafield, 'field': datafield, 'can_edit_datafield': can_edit_datafield} %}
-                {% else %}
-                    {# user can't view or edit datafield, don't display anything #}
-                {% endif %}
-
-                </div><!-- end of #Field_{{ datafield.id }} -->
+            {% if field_typename == "Markdown" %}
+                {% include 'ODRAdminBundle:Results:results_markdown.html.twig' with {'field': datafield} %}
+            {% elseif can_view_datafield == 1 %}
+                {% include 'ODRAdminBundle:MassEdit:massedit_datafield.html.twig' with {'fieldtheme': theme_datafield, 'field': datafield, 'can_edit_datafield': can_edit_datafield} %}
+            {% else %}
+                {# user can't view or edit datafield, don't display anything #}
             {% endif %}
+
+            </div><!-- end of #Field_{{ datafield.id }} -->
 
         {% endfor %}
     {% elseif data.datatype != null %}
         {# render the child/linked datatype in this theme element #}
-{#
-        {% import "ODRAdminBundle:Displaytemplate:design_area_childtype.html.twig" as mychildform %}
+
+        {% import "ODRAdminBundle:MassEdit:massedit_childtype.html.twig" as mychildform %}
         {{ mychildform.input(data.datatype, datafield_permissions) }}
-#}
+
     {% endif %}
 
 
     {# inverse of "if datatype_tree.is_link == 1 and element.displayinresults == 0" #}
-    {% if datatype_tree.is_link == 0 or element.displayinresults == 1 %}
+    {#{% if datatype_tree.is_link == 0 or element.displayinresults == 1 %}#}
+    {% if datatype_tree.is_link == 0 %}
             </div><!-- End of .ODRInnerBox -->
         </div><!-- End of #ThemeElement_{{ element.id }} -->
     {% endif %}

--- a/src/ODR/AdminBundle/Resources/views/Record/record_ajax.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Record/record_ajax.html.twig
@@ -115,7 +115,8 @@ function initPage() {
         var href = $(this).attr('href');
 
         var short_form = false;
-        handleFileDownload(event, file_id, href, short_form);
+        var can_cancel = true;
+        handleFileDownload(event, file_id, href, short_form, can_cancel);
     });
 
     $(".ODRDataField").find('.ODRDatafieldHistory').unbind('click');
@@ -282,9 +283,27 @@ function initPage() {
         }
     });
 
+
     $(".ODRPublicFile").unbind('click');
-    $(".ODRPublicFile").click(function() {
+    $(".ODRPublicFile").click(function(event) {
+        // Grab necessary attributes
         var file_id = $(this).attr('rel');
+        var href = $(this).attr('href');
+
+        var public_div = $(this);
+
+        // Don't change public status of file if it's currently being decrypted
+        if ( pending_file_decryptions[file_id] != null || pending_file_decryptions[file_id] != undefined || file_decrypt_timeouts[file_id] != null || file_decrypt_timeouts[file_id] != undefined) {
+//            alert('in progress');
+            return false;
+        }
+
+        if ( $(public_div).hasClass('IconRed') ) {
+            // Only display decryption progress bar if file is being made public
+            var short_form = false;
+            var can_cancel = false;
+            handleFileDownload(event, file_id, href, short_form, can_cancel);
+        }
 
         var url  = '{{ path('odr_record_public_file', {'file_id': 0} ) }}';
         url = url.substring(0,(url.length-1));
@@ -300,10 +319,20 @@ function initPage() {
             dataType: "json",
             success: function(data, textStatus, jqXHR) {
                 if(data.r == 0) {
-                    // Reload the file control
-                    var datarecord_id = data.d.datarecord;
-                    var datafield_id = data.d.datafield;
-                    ReloadDatafield(datarecord_id, datafield_id);
+
+                    if ( data.d.is_public ) {
+                        // File is now public
+                        $(public_div).removeClass('IconRed');
+                        $(public_div).attr('title', 'Public since ' + data.d.public_date);
+
+                        // Hide the decryption progress bar
+                        $("#ODRFileDownload_" + file_id).hide();
+                    }
+                    else {
+                        // File is now non-public
+                        $(public_div).addClass('IconRed');
+                        $(public_div).attr('title', 'File is not public');
+                    }
                 }
                 else {
                     // An error has occurred.

--- a/src/ODR/AdminBundle/Resources/views/Record/record_ajax.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Record/record_ajax.html.twig
@@ -401,6 +401,58 @@ function initPage() {
         });
     });
 
+    $(".ODRRotateImage").unbind('click');
+    $(".ODRRotateImage").click(function() {
+        var image_id = $(this).attr('rel');
+
+        var direction = 1;
+        if ( $(this).hasClass('fa-rotate-left') )
+            direction = -1;
+
+        var url  = '{{ path('odr_record_rotate_image', {'image_id': 0, 'direction': 1} ) }}';
+        url = url.substring(0,(url.length-3));
+        url += image_id + '/' + direction;
+
+//alert( url );
+//return;
+
+        var tmp = $(this).parents(".ODRDataField").first().attr('id');
+        tmp = tmp.split('_');
+        var datarecord_id = tmp[1];
+        var datafield_id = tmp[2];
+
+        $.ajax({
+            cache: false,
+            type: 'GET',
+            url: url,
+            dataType: "json",
+            success: function(data, textStatus, jqXHR) {
+                if(data.r == 0) {
+                    // Reload the image datafield
+                    ReloadDatafield(datarecord_id, datafield_id);
+                }
+                else {
+                    // An error has occurred.
+                    // Show Error message dialog
+                    alert(data.d);
+                }
+            },
+            complete: function(jqXHR, textStatus) {
+                // Get the xdebugToken from response headers
+                var xdebugToken = jqXHR.getResponseHeader('X-Debug-Token');
+
+                // If the Sfjs object exists
+                if (typeof Sfjs !== "undefined") {
+                    // Grab the toolbar element
+                    var currentElement = $('.sf-toolbar')[0];
+
+                    // Load the data of the given xdebug token into the current toolbar wrapper
+                    Sfjs.load(currentElement.id, '/app_dev.php/_wdt/'+ xdebugToken);
+                }
+            }
+        });
+    });
+
     $(".ODRPublicChildRecord").unbind('click');
     $(".ODRPublicChildRecord").click(function() {
         var datarecord_id = $(this).attr('rel');

--- a/src/ODR/AdminBundle/Resources/views/Record/record_datafield.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Record/record_datafield.html.twig
@@ -65,7 +65,7 @@
                             <td class="pure-u-20-24" {% if file.originalfilename != null and field.getshortenfilename == 1 and file.originalfilename|length > 35 %}title="{{ file.originalfilename }}"{% endif %}>
                                 {% if file.getoriginalchecksum != '' %}
                                     <a href="{{ path('odr_file_download', { 'file_id': file.id } ) }}" class="truncate ODRFileDownload" rel="{{ file.id }}">
-                                        {% if file.originalfilename == null %}File_{{ file.id }}.txt{% else %}{{ file.originalfilename }}{% endif %}
+                                        {% if file.originalfilename == null %}File_{{ file.id }}.{{ file.getext }}{% else %}{{ file.originalfilename }}{% endif %}
                                     </a>
                                     <span id="ODRFileDownload_{{ file.id }}" class="ODRFileDownloadProgress" style="cursor:default; margin-left:10px;">
                                         <span id="ODRFileDecrypt_{{ file.id }}_progress" class="ODRProgressBar" style="margin-left:15px; display:inline-block;">

--- a/src/ODR/AdminBundle/Resources/views/Record/record_datafield.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Record/record_datafield.html.twig
@@ -145,11 +145,13 @@
                             <div class="pure-u-1">
                                 &nbsp;<i class="ODRDeleteImage tooltip Pointer fa fa-lg fa-trash-o" title="Delete Image" rel="{{ oimage.id }}"></i>
                                 &nbsp;<i class="ODRPublicImage tooltip Pointer fa fa-lg fa-globe {% if oimage.ispublic == 0 %}IconRed{% endif %}" title="{% if oimage.ispublic == 0 %}Image is not public{% else %}Public since {{ oimage.publicdate|date('Y-m-d') }}{% endif %}" rel="{{ oimage.id }}"></i>
+                                &nbsp;<i class="ODRRotateImage tooltip Pointer fa fa-lg fa-rotate-left" title="Rotate Image 90 degrees counter-clockwise" rel="{{ oimage.id }}"></i>
+                                &nbsp;<i class="ODRRotateImage tooltip Pointer fa fa-lg fa-rotate-right" title="Rotate Image 90 degrees clockwise" rel="{{ oimage.id }}"></i>
                                 &nbsp;
                             </div>
                             <div class="pure-u-23-24">
                                 <a target="_blank" href="{{ path('odr_image_download', {'image_id': oimage.id}) }}" title="{{ oimage.caption }}">
-                                    <img class="pure-img" src="{{ path('odr_image_download', {'image_id': image.id}) }}" title="{% if image.originalfilename != null %}{{ image.originalfilename }}{% else %}Image_{{ image.id }}.{{ image.ext }}{% endif %}" />
+                                    <img class="pure-img" src="{{ path('odr_image_download', {'image_id': image.id}) }}{% if force_image_reload %}?{{ date().timestamp }}{% endif %}" title="{% if image.originalfilename != null %}{{ image.originalfilename }}{% else %}Image_{{ image.id }}.{{ image.ext }}{% endif %}" />
                                 </a>
                             </div>
                         </div>

--- a/src/ODR/AdminBundle/Resources/views/Record/record_fields.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Record/record_fields.html.twig
@@ -61,7 +61,7 @@
                 {% if datafield.fieldtype.typename == "Markdown" %}
                     {% include 'ODRAdminBundle:Results:results_markdown.html.twig' with {'field': datafield} %}
                 {% elseif datatype_tree.is_link == 0 and can_view_datafield == 1 and can_edit_datafield == 1 %}
-                    {% include 'ODRAdminBundle:Record:record_datafield.html.twig' with {'fieldtheme': theme_datafield, 'field': datafield, 'datatype': datatype, 'datarecord': datarecord, 'datarecordfield': drf_list[datafield_id], 'form': form_list[datafield_id]} %}
+                    {% include 'ODRAdminBundle:Record:record_datafield.html.twig' with {'fieldtheme': theme_datafield, 'field': datafield, 'datatype': datatype, 'datarecord': datarecord, 'datarecordfield': drf_list[datafield_id], 'form': form_list[datafield_id], 'force_image_reload' : false} %}
                 {% elseif can_view_datafield == 1 %}
                     {% include 'ODRAdminBundle:Results:results_datafield.html.twig' with {'fieldtheme': theme_datafield, 'field': datafield, 'datatype': datatype, 'datarecord': datarecord, 'datarecordfield': drf_list[datafield_id], 'form': form_list[datafield_id], 'public_only': false} %}
                 {% else %}

--- a/src/ODR/AdminBundle/Resources/views/Results/results_ajax.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Results/results_ajax.html.twig
@@ -58,7 +58,8 @@ function initPage() {
         var href = $(this).attr('href');
 
         var short_form = false;
-        handleFileDownload(event, file_id, href, short_form);
+        var can_cancel = true;
+        handleFileDownload(event, file_id, href, short_form, can_cancel);
     });
 }
 

--- a/src/ODR/AdminBundle/Resources/views/Results/results_childtype.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Results/results_childtype.html.twig
@@ -14,17 +14,16 @@
 
         {% for dr_entry in datarecord_tree %}
             {% set datarecord = dr_entry.datarecord %}
-
 {#
 ----------</br>
+override_child: true </br>
 datarecord: {{ datarecord.id }} </br>
 top_level: {{ datatype_tree.top_level }} </br>
 display_type: {{ datatype.getdisplaytype }} </br>
 is_public: {{ datarecord.ispublic }} </br>
-public_only: {{ public_only}} </br>
+public_only: {{ public_only }} </br>
 ----------</br>
 #}
-
             {% if datatype_tree.top_level == 0 and datatype.getdisplaytype == 0 and (datarecord.ispublic == true or public_only == false) %}
                 <h3 class="ui-accordion-header ui-helper-reset ui-state-default ui-state-active" role="tab" aria-expanded="true" aria-selected="true" tabindex="0">
                     <span class="ui-icon ui-icon-triangle-1-s"></span>
@@ -44,13 +43,17 @@ public_only: {{ public_only}} </br>
                 </h3>
             {% endif %}
 
-            <div class="ODRFieldArea accordion-content pure-u-1" id="FieldArea_{{ datarecord.id }}">
-                {% include 'ODRAdminBundle:Results:results_fields.html.twig' with {'datatype_tree': datatype_tree, 'dr_entry': dr_entry, 'theme': theme, 'public_only': public_only} %}
-            </div><!-- End of #FieldArea_{{ datarecord.id }} -->
-        {% endfor %}
-    {% endif %}
+            {% if datarecord.ispublic == true or public_only == false %}
+                <div class="ODRFieldArea accordion-content pure-u-1" id="FieldArea_{{ datarecord.id }}">
+                    {% include 'ODRAdminBundle:Results:results_fields.html.twig' with {'datatype_tree': datatype_tree, 'dr_entry': dr_entry, 'theme': theme, 'public_only': public_only} %}
+                </div><!-- End of #FieldArea_{{ datarecord.id }} -->
+            {% endif %}
 
-    {% include 'ODRAdminBundle:Default:accordion_footer.html.twig' with {'childtype': datatype} %}
+        {% endfor %}
+
+        {% include 'ODRAdminBundle:Default:accordion_footer.html.twig' with {'childtype': datatype} %}
+
+    {% endif %}
 
 {% else %}
     <!-- Child Types -->
@@ -62,11 +65,12 @@ public_only: {{ public_only}} </br>
             {% set datarecord = dr_entry.datarecord %}
 {#
 ----------</br>
+override_child: false </br>
 datarecord: {{ datarecord.id }} </br>
 top_level: {{ datatype_tree.top_level }} </br>
 display_type: {{ datatype.getdisplaytype }} </br>
 is_public: {{ datarecord.ispublic }} </br>
-public_only: {{ public_only}} </br>
+public_only: {{ public_only }} </br>
 ----------</br>
 #}
             {% if datatype_tree.top_level == 0 and datatype.getdisplaytype == 0 and (datarecord.ispublic == true or public_only == false) %}

--- a/src/ODR/AdminBundle/Resources/views/Results/results_datafield.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/Results/results_datafield.html.twig
@@ -33,7 +33,7 @@
                             <td class="pure-u-20-24" {% if file.originalfilename != null and field.getshortenfilename == 1 and file.originalfilename|length > 35 %}title="{{ file.originalfilename }}"{% endif %}>
                                 {% if file.getoriginalchecksum != '' %}
                                     <a href="{{ path('odr_file_download', { 'file_id': file.id } ) }}" class="truncate ODRFileDownload" rel="{{ file.id }}">
-                                        {% if file.originalfilename == null %}File_{{ file.id }}.txt{% else %}{{ file.originalfilename }}{% endif %}
+                                        {% if file.originalfilename == null %}File_{{ file.id }}.{{ file.getext }}{% else %}{{ file.originalfilename }}{% endif %}
                                     </a>
                                     <span id="ODRFileDownload_{{ file.id }}" class="ODRFileDownloadProgress" style="cursor:default; margin-left:10px;">
                                         <span id="ODRFileDecrypt_{{ file.id }}_progress" class="ODRProgressBar" style="margin-left:15px; display:inline-block;">

--- a/src/ODR/AdminBundle/Resources/views/ShortResults/shortresults_datafield.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/ShortResults/shortresults_datafield.html.twig
@@ -32,7 +32,7 @@
                         <tr id="File_{{ file.id }}" class="pure-u-1">
                             <td class="pure-u-20-24" {% if file.originalfilename != null and field.getshortenfilename == 1 and file.originalfilename|length > 35 %}title="{{ file.originalfilename }}"{% endif %}>
                                 <a href="{{ path('odr_file_download', { 'file_id': file.id } ) }}" class="truncate ODRFileDownload" rel="{{ file.id }}">
-                                    {% if file.originalfilename == null %}File_{{ file.id }}.txt{% else %}{{ file.originalfilename }}{% endif %}
+                                    {% if file.originalfilename == null %}File_{{ file.id }}.{{ file.getext }}{% else %}{{ file.originalfilename }}{% endif %}
                                 </a>
                                 <span id="ODRFileDownload_{{ file.id }}" class="ODRFileDownloadProgress" style="cursor:default; margin-left:10px;">
                                     <span id="ODRFileDecrypt_{{ file.id }}_progress" class="ODRProgressBar" style="margin-left:15px; display:inline-block;">

--- a/src/ODR/AdminBundle/Resources/views/ShortResults/shortresultslist.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/ShortResults/shortresultslist.html.twig
@@ -90,7 +90,8 @@
 
             // Prevent the click handler for <tr> elements from firing if a file download href is clicked
             var short_form = true;
-            handleFileDownload(event, file_id, href, short_form);
+            var can_cancel = true;
+            handleFileDownload(event, file_id, href, short_form, can_cancel);
         });
 
         // Hide empty fieldareas

--- a/src/ODR/AdminBundle/Resources/views/ShortResults/shortresultslist.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/ShortResults/shortresultslist.html.twig
@@ -22,8 +22,10 @@
     <div class="ODRShortResult">
     {{ html | raw }}
     </div>
+{% elseif logged_in %}
+    <center>No Datarecords found</center>
 {% else %}
-    <center>No Records found!</center>
+    <center>No Datarecords found...try logging in</center>
 {% endif %}
 
 </div><!-- End of .ODRFormWrap -->

--- a/src/ODR/AdminBundle/Resources/views/TextResults/textresultslist.html.twig
+++ b/src/ODR/AdminBundle/Resources/views/TextResults/textresultslist.html.twig
@@ -123,7 +123,7 @@
             },
 
             "language": {
-                "emptyTable": "No Datarecords found"
+                "emptyTable": {% if logged_in %}"No Datarecords found"{% else %}"No Datarecords found...try logging in"{% endif %}
             }
 
         });

--- a/src/ODR/OpenRepository/SearchBundle/Controller/DefaultController.php
+++ b/src/ODR/OpenRepository/SearchBundle/Controller/DefaultController.php
@@ -1550,7 +1550,8 @@ if ($debug)
                 $datarecords = $odrcc->getSortedDatarecords($datatype);
             }
 
-print '$datarecords: '.$datarecords."\n";
+if ($debug)
+    print '$datarecords: '.$datarecords."\n";
 
             // --------------------------------------------------
             // Store the list of datarecord ids for later use
@@ -1563,8 +1564,11 @@ print '$datarecords: '.$datarecords."\n";
 
             $cached_searches = $memcached->get($memcached_prefix.'.cached_search_results');
 
-print '$cached_searches: '.print_r($cached_searches, true)."\n";
-exit();
+if ($debug) {
+    print '$cached_searches: '.print_r($cached_searches, true)."\n";
+    exit();
+}
+
             // Create pieces of the array if they don't exist
             if ($cached_searches == null)
                 $cached_searches = array();

--- a/src/ODR/OpenRepository/SearchBundle/Controller/DefaultController.php
+++ b/src/ODR/OpenRepository/SearchBundle/Controller/DefaultController.php
@@ -1743,6 +1743,9 @@ if ($timing)
             $grandparents = '';
 
             if ( $general_string === null && count($searched_datafields) == 0 && count($metadata) == 0 ) {
+                // Ensure that datarecord_id 0 doesn't get in the final search results...
+                unset( $matched_datarecords[0] );
+
                 // In the case when there was nothing entered in the search at all...every possible datarecord satisfies the search
                 foreach ($matched_datarecords as $dr_id => $flag)
                     $datarecords .= $dr_id.',';

--- a/src/ODR/OpenRepository/SearchBundle/Controller/DefaultController.php
+++ b/src/ODR/OpenRepository/SearchBundle/Controller/DefaultController.php
@@ -894,6 +894,16 @@ if ($debug) {
 
 $debug = true;
 $debug = false;
+$more_debug = true;
+$more_debug = false;
+$timing = true;
+$timing = false;
+
+$start_time = microtime(true);
+
+if ($debug || $more_debug || $timing)
+    print '<pre>';
+
 if ($debug) {
     print 'cached datarecord str: '.$cached_datarecord_str."\n";
 }
@@ -997,29 +1007,25 @@ if ($debug) {
 
             $encoded_search_key = substr($encoded_search_key, 0, -1);
 if ($debug) {
-//$params = $request->query->all();
-//print '$_GET string: '.print_r($params, true)."\n\n";
-
     print 'search_key: '.$search_key."\n";
     print 'md5('.$search_key.'): '.md5($search_key)."\n";
     print 'encoded_search_key: '.$encoded_search_key."\n";
     print 'md5('.$encoded_search_key.'): '.md5($encoded_search_key)."\n";
     print 'post: '.print_r($post, true)."\n";
 }
-//return;
-
-            //
-            $searched_datafields = array();
-            foreach ($post['datafields'] as $df_id => $df_value)
-                $searched_datafields[] = $df_id;
-            $searched_datafields = implode(',', $searched_datafields);
 
             $target_datatype_id = $post['dt_id'];
             $datatype = $repo_datatype->find($target_datatype_id);
             if ($datatype == null)
                 return array('message' => "This datatype is deleted", 'encoded_search_key' => $encoded_search_key);
 
-            $session->set('prev_searched_datatype_id', $target_datatype_id);
+
+            // General Search will search all datafields of these fieldtypse that belong to this datatype and its childtypes
+            $search_entities = array('ShortVarchar', 'MediumVarchar', 'LongVarchar', 'LongText', 'IntegerValue', 'Radio');   // TODO - DecimalValue too? or not...
+            // NOTE - this purposefully ignores boolean...otherwise a general search string of '1' would return all checked boolean entities, and '0' would return all unchecked boolean entities
+
+
+            $session->set('prev_searched_datatype_id', $target_datatype_id);    // TODO - storing previously searched datatype in session doesn't really work for users
 
             $datafields = array();
             if ( isset($post['datafields']) )
@@ -1027,17 +1033,6 @@ if ($debug) {
             $general_string = null;
             if ( isset($post['gen']) )
                 $general_string = trim($post['gen']);
-
-            // Get rid of empty/blank search strings for datafields
-//            if ($datafields !== null) {
-                foreach ($datafields as $id => $str) {
-                    if ( !is_array($str) && trim($str) === '' )
-                        unset( $datafields[$id] );
-                }
-
-//                if ( count($datafields) == 0 )
-//                    $datafields = null;
-//            }
 
 
             // --------------------------------------------------
@@ -1053,24 +1048,29 @@ if ($debug) {
                 $user_permissions = $odrcc->getPermissionsArray($user->getId(), $request);
             }
 
-if ($debug) {
-//    print 'logged_in: '.$logged_in."\n";
-//    print 'has_view_permission: '.$has_view_permission."\n";
-//    print '$user_permissions: '.print_r($user_permissions, true)."\n";
-}
-            $using_adv_search = false;
-            $basic_search_datarecords = array();
-            $adv_search_datarecords = array();
+
+            // --------------------------------------------------
+            // Get rid of empty/blank search strings for datafields
+            foreach ($datafields as $id => $str) {
+                if ( !is_array($str) && trim($str) === '' )
+                    unset( $datafields[$id] );
+            }
+
+            // Keep track of the datafields that are being searched on...this will get stored in memcached so cached searches involving these datafield can be deleted when changes are made to their contents
+            $searched_datafields = array();
+            foreach ($datafields as $df_id => $search_value)
+                $searched_datafields[] = $df_id;
 
 
             // --------------------------------------------------
             // Grab all datatypes related to the one being searched
+            $searched_datatypes = array();
             $related_datatypes = self::getRelatedDatatypes($em, $target_datatype_id, $user_permissions);
 
 if ($debug)
     print '$related_datatypes: '.print_r($related_datatypes, true)."\n";
 
-            // The next query needs just a comma separated list of datatype ids...
+            // The next DQL query needs a comma separated list of datatype ids...
             $datatype_list = array();
             foreach ($related_datatypes['child_datatypes'] as $child_datatype_id => $tmp)
                 $datatype_list[] = $child_datatype_id;
@@ -1079,7 +1079,7 @@ if ($debug)
 
 
             // TODO - partial duplicate of self::getSearchableDatafields()...
-            // Grab typeclasses for each of the searchable datafields in this DataType
+            // Grab typeclasses for each of the searchable datafields in all datatypes related to the target datatype
             $query_str =
                'SELECT ft.typeClass AS type_class, dt.id AS dt_id, dt.publicDate AS dt_public_date, df.id AS df_id, df.user_only_search AS user_only_search
                 FROM ODRAdminBundle:DataFields AS df
@@ -1091,7 +1091,7 @@ if ($debug)
             $results = $query->getArrayResult();
 
             // Organize the datafields into lists, and remove the ones the user can't search
-            $datafield_array = array('by_typeclass' => array(), 'by_id' => array(), 'datatype_of' => array());
+            $datafield_array = array('by_typeclass' => array(), 'by_id' => array(), 'datatype_of' => array(), 'by_datatype' => array());
             foreach ($results as $num => $result) {
                 $typeclass = $result['type_class'];
                 $dt_id = $result['dt_id'];
@@ -1116,20 +1116,34 @@ if ($debug)
                     /* either the datafield isn't visible to non-logged in users, or the user isn't allowed to see the datatype itself...either way, don't save the datafield */
                 }
                 else {
-                    // ...first list being by typeclass, to use during general search
-                    if ( !isset($datafield_array['by_typeclass'][$typeclass]) )
-                        $datafield_array['by_typeclass'][$typeclass] = array();
-                    $datafield_array['by_typeclass'][$typeclass][$dt_id][] = $df_id;
+                    // The first list of datafield ids is organized by typeclass then by datatype, and is used during general search
+                    if ( in_array($typeclass, $search_entities) ) {
+                        if (!isset($datafield_array['by_typeclass'][$typeclass]))
+                            $datafield_array['by_typeclass'][$typeclass] = array();
+                        $datafield_array['by_typeclass'][$typeclass][$dt_id][] = $df_id;
 
-                    // ...second list being by datafield, to use during advanced search
+                        if ($general_string !== null)
+                            $searched_datatypes[] = $dt_id;
+                    }
+
+                    // The second list stores the typeclass for each datafield, and is used during advanced search
                     $datafield_array['by_id'][$df_id] = $typeclass;
 
-                    // ...third list mentioning what datatype they belong to
+                    // The third list stores the datatype id for each datafield, and is used for finding some query errors and also during advanced search
                     $datafield_array['datatype_of'][$df_id] = $dt_id;
+
+                    // The fourth list stores the datafields for each datatype...makes computing the intersection of search results easier after general/advanced searches are completed
+                    if ( !isset($datafield_array['by_datatype'][$dt_id]) )
+                        $datafield_array['by_datatype'][$dt_id] = array();
+                    $datafield_array['by_datatype'][$dt_id][] = $df_id;
+
+
+                    // Also store the datatypes of the datafields the user is searching on
+                    if ( in_array($df_id, $searched_datafields) )
+                        $searched_datatypes[] = $dt_id;
                 }
             }
-if ($debug)
-    print '$datafield_array: '.print_r($datafield_array, true)."\n";
+
 
             // --------------------------------------------------
             // Deal with metadata, if it exists
@@ -1139,8 +1153,16 @@ if ($debug)
 
                 // Fix the metadata array
                 foreach ($metadata as $datatype_id => $data) {
+                    // This datatype is being searched on
+                    $searched_datatypes[] = $datatype_id;
+
+                    // In case one of the searched datafields doesn't cover it, ensure an entry exists for this datatype's metadata...will be used later during the intersection calculations
+                    if ( !isset($datafield_array['by_datatype'][$datatype_id]) )
+                        $datafield_array['by_datatype'][$datatype_id] = array();
+                    $datafield_array['by_datatype'][$datatype_id][] = 'dt_'.$datatype_id.'_metadata';
+
                     foreach ($data as $key => $tmp) {
-                        // Don't change the public key
+                        // Don't change the public_date key
                         if ($key == 'public')
                             continue;
 
@@ -1159,7 +1181,6 @@ if ($debug)
                             $date_end->add(new \DateInterval('P1D'));
                             $date_end = $date_end->format('Y-m-d');
                             $metadata[$datatype_id][$key]['end'] = $date_end;
-
 if ($debug)
     print 'changed $'.$key.'_date_end to '.$date_end."\n";
 
@@ -1202,25 +1223,184 @@ if ($debug)
                 }
             }
 
-if ($debug)
-    print '$metadata: '.print_r($metadata, true)."\n";
-//exit();
+            // Not strictly necessary, but remove any duplicates from the array of datatypes being searched on
+            $searched_datatypes = array_unique($searched_datatypes);
 
+if ($debug) {
+    print '$datafield_array: '.print_r($datafield_array, true)."\n";
+    print '$metadata: '.print_r($metadata, true)."\n";
+    print '$searched_datatypes: '.print_r($searched_datatypes, true)."\n";
+//exit();
+}
+
+if ($timing)
+    print 'base arrays built in: '.((microtime(true) - $start_time)*1000)."ms \n";
+
+            // --------------------------------------------------
+            // Get all top-level datarecords of this datatype that could possibly match the desired search
+            // ...has to be done this way so that when the user searches on criteria for both childtypes A and B, a top-level datarecord that only has either childtype A or childtype B won't match
+            $allowed_grandparents = null;
+            foreach ($searched_datatypes as $num => $dt_id) {
+                // Doesn't matter if the the top-level datatype is being searched on...
+                if ($dt_id == $target_datatype_id)
+                    continue;
+
+                // Linked datarecords needs a different query to extract "grandparents", since we actually want the grandparent of the datarecord that is linking to this linked datarecord
+                $sub_query = null;
+                if ( in_array($dt_id, $related_datatypes['linked_datatypes']) ) {
+                    $sub_query = $em->createQuery(
+                       'SELECT grandparent.id
+                        FROM ODRAdminBundle:DataRecord AS ldr
+                        JOIN ODRAdminBundle:LinkedDataTree AS ldt WITH ldr = ldt.descendant
+                        JOIN ODRAdminBundle:DataRecord AS dr WITH dr = ldt.ancestor
+                        JOIN ODRAdminBundle:DataRecord AS grandparent WITH grandparent = dr.grandparent
+                        WHERE ldr.dataType = :linked_datatype_id AND grandparent.dataType = :target_datatype_id
+                        AND ldr.deletedAt IS NULL AND ldt.deletedAt IS NULL AND dr.deletedAt IS NULL AND grandparent.deletedAt IS NULL'
+                    )->setParameters( array('linked_datatype_id' => $dt_id, 'target_datatype_id' => $target_datatype_id) );
+                }
+                else {
+                    $sub_query = $em->createQuery(
+                       'SELECT grandparent.id
+                        FROM ODRAdminBundle:DataRecord AS dr
+                        JOIN ODRAdminBundle:DataRecord AS grandparent WITH dr.grandparent = grandparent
+                        WHERE dr.dataType = :dt_id AND grandparent.dataType = :target_datatype_id
+                        AND dr.deletedAt IS NULL AND grandparent.deletedAt IS NULL'
+                    )->setParameters(array('dt_id' => $dt_id, 'target_datatype_id' => $target_datatype_id));
+                }
+                $result = $sub_query->getArrayResult();
+
+                // Flatten the array doctrine returns so array_intersect works properly
+                $sub_result = array();
+                foreach ($result as $tmp => $data)
+                    $sub_result[] = $data['id'];
+                $sub_result = array_unique($sub_result);
+
+                // Intersect the flattened array with the array of currently allowed top-level datarecords
+                if ($allowed_grandparents == null)
+                    $allowed_grandparents = $sub_result;
+                else
+                    $allowed_grandparents = array_intersect($allowed_grandparents, $sub_result);
+            }
+
+
+            // Get every single child datarecord of each of the allowed top-level datarecords
+            $parameters = array();
+            $query_str =
+               'SELECT dr.id AS dr_id, parent.id AS parent_id, dt.id AS datatype_id
+                FROM ODRAdminBundle:DataRecord as dr
+                JOIN ODRAdminBundle:DataType AS dt WITH dr.dataType = dt
+                JOIN ODRAdminBundle:DataRecord AS parent WITH dr.parent = parent
+                JOIN ODRAdminBundle:DataRecord AS grandparent WITH dr.grandparent = grandparent
+                WHERE grandparent.dataType = :target_datatype';
+            $parameters['target_datatype'] = $target_datatype_id;
+
+            // If there's some restriction on the top-level datarecords to return, splice that into the query
+            if ( $allowed_grandparents !== null && count($allowed_grandparents) > 0 ) {
+                $query_str .= ' AND grandparent.id IN (:allowed_grandparents)';
+                $parameters['allowed_grandparents'] = $allowed_grandparents;
+            }
+            $query_str .= ' AND dr.deletedAt IS NULL AND parent.deletedAt IS NULL AND grandparent.deletedAt IS NULL AND dt.deletedAt IS NULL';
+
+            // Run the query to get all child datarecords
+            $query = $em->createQuery($query_str)->setParameters($parameters);
+            $child_datarecords = $query->getArrayResult();
+
+
+            // Get every single linked datarecord of each of the allowed top-level datarecords
+            $parameters = array();
+            $query_str =
+               'SELECT ldr.id AS dr_id, parent.id AS parent_id, ldr_dt.id AS datatype_id
+                FROM ODRAdminBundle:DataRecord as ldr
+                JOIN ODRAdminBundle:DataType AS ldr_dt WITH ldr.dataType = ldr_dt
+                JOIN ODRAdminBundle:LinkedDataTree AS ldt WITH ldt.descendant = ldr
+                JOIN ODRAdminBundle:DataRecord AS parent WITH ldt.ancestor = parent
+                JOIN ODRAdminBundle:DataRecord AS grandparent WITH parent.grandparent = grandparent
+                WHERE grandparent.dataType = :target_datatype';
+            $parameters['target_datatype'] = $target_datatype_id;
+
+            // If there's some restriction on the top-level datarecords to return, splice that into the query
+            if ( $allowed_grandparents !== null && count($allowed_grandparents) > 0 ) {
+                $query_str .= ' AND grandparent.id IN (:allowed_grandparents)';
+                $parameters['allowed_grandparents'] = $allowed_grandparents;
+            }
+            $query_str .= ' AND ldr.deletedAt IS NULL AND ldr_dt.deletedAt IS NULL AND ldt.deletedAt IS NULL AND parent.deletedAt IS NULL AND grandparent.deletedAt IS NULL';
+
+            // Run the query to get all linked datarecords
+            $query = $em->createQuery($query_str)->setParameters($parameters);
+            $linked_datarecords = $query->getArrayResult();
+
+
+            // Merge all child and linked datarecords together into the same array
+            $results = array_merge($child_datarecords, $linked_datarecords);
+
+
+            // @see self::buildDatarecordTree() for structure of this array
+            $descendants_of_datarecord = array();
+
+            // Need to recursively enforce these logical rules for searching...
+            // 1) A child datarecord of a child datatype that isn't being directly searched on is automatically included if its parent is included
+            // 2) A datarecord of a datatype that is being directly searched on must match criteria to be included
+            // 3) If none of the child datarecords of a given child datatype for a given parent datarecord match the search query, that parent datarecord must also be excluded
+
+            // $matched_datarecords is an array where every single datarecord id listed in $descendants_of_datarecord points to the integers -1, 0, or 1
+            // -1 denotes "does not match search, exclude", 0 denotes "not being searched on", and 1 denotes "matched search"
+            // All datarecords of every datatype that are being searched on are initialized to -1...their contents must match the search for them to be included in the results.
+            // During the very last phase of searching, $descendants_of_datarecords is recursively traversed...datarecords with a 0 or 1 are included in the final list of search results unless it would violate rule 3 above.
+            $matched_datarecords = array();
+
+            foreach ($results as $result) {
+                $dr_id = $result['dr_id'];
+                $parent_id = $result['parent_id'];
+                $dt_id = $result['datatype_id'];
+
+                // Keep track of which children this datarecord has
+                if ($dr_id == $parent_id) {
+                    // ...this is a top-level datarecord
+                    if ( !isset($descendants_of_datarecord[0]) ) {
+                        $descendants_of_datarecord[0] = array();
+                        $descendants_of_datarecord[0][$target_datatype_id] = array();
+                    }
+                    $descendants_of_datarecord[0][$target_datatype_id][$dr_id] = '';
+                }
+                else {
+                    // ...this is a some child or linked datarecord
+                    if ( !isset($descendants_of_datarecord[$parent_id]) )
+                        $descendants_of_datarecord[$parent_id] = array();
+                    if ( !isset($descendants_of_datarecord[$parent_id][$dt_id]) )
+                        $descendants_of_datarecord[$parent_id][$dt_id] = array();
+                    $descendants_of_datarecord[$parent_id][$dt_id][$dr_id] = '';
+                }
+
+                // If this datarecord's datatype is being searched on somehow...require any datarecords of that datatype to be directly matched by the search queries
+                $flag = 0;
+                if ( in_array($dt_id, $searched_datatypes) )
+                    $flag = -1;
+
+                $matched_datarecords[$dr_id] = $flag;
+            }
+
+            // $descendants_of_datarecord array is currently partially flattened..."inflate" it into the true tree structure described above
+            $matched_datarecords[0] = 0;
+            $descendants_of_datarecord = array(0 => self::buildDatarecordTree($descendants_of_datarecord, 0));
+
+if ($more_debug) {
+    print '$matched_datarecords: '.print_r($matched_datarecords, true)."\n";
+    print '$descendants_of_datarecord: '.print_r($descendants_of_datarecord, true)."\n";
+}
+
+
+if ($timing)
+    print 'datarecord trees built in: '.((microtime(true) - $start_time)*1000)."ms \n";
 
             // --------------------------------------------------
             // General search
-            if (trim($general_string) !== '') {
+            $basic_results = array();
+            if ($general_string !== null) {
 
                 // Assume user wants exact search...
-                $general_search_params = self::parseField($general_string, $debug);
-if ($debug)
+                $general_search_params = self::parseField($general_string, $more_debug);
+if ($more_debug)
     print '$general_search_params: '.print_r($general_search_params, true)."\n";
-
-                $basic_results = array();
-                // Search all datafields belonging to this datatype that are of these fieldtypes
-                $search_entities = array('ShortVarchar', 'MediumVarchar', 'LongVarchar', 'LongText', 'IntegerValue', 'Radio');   // TODO - DecimalValue too? or not...
-
-                // NOTE - this purposefully ignores boolean...otherwise a general search string of '1' would return all checked boolean entities, and '0' would return all unchecked boolean entities
 
                 foreach ($search_entities as $typeclass) {
                     // Grab list of datafields to search with this typeclass
@@ -1233,12 +1413,9 @@ if ($debug)
                         if ( in_array($datatype_id, $related_datatypes['linked_datatypes']) )
                             continue;
 
-//print '$datafields: '.print_r($datafields, true)."\n";
-
                         $results = array();
                         if ($typeclass == 'Radio') {
                             // Radio requires a different set of parameters
-                            $general_string = trim($general_string);
                             $comparision = '=';
 
                             // If general_string has quotes around it, strip them
@@ -1259,51 +1436,33 @@ if ($debug)
                             );
 
                             // Run the radio-typeclass-specific query
-                            $results = self::runSearchQuery($em, $datafield_list, $typeclass, $datatype_id, $radio_search_params, $related_datatypes, $metadata);
+                            $results = self::runSearchQuery($em, $datafield_list, $typeclass, $datatype_id, $radio_search_params, $related_datatypes, $metadata, $more_debug);
                         }
                         else {
                             // Run the query for most of the typeclasses
-                            $results = self::runSearchQuery($em, $datafield_list, $typeclass, $datatype_id, $general_search_params, $related_datatypes, $metadata);
+                            $results = self::runSearchQuery($em, $datafield_list, $typeclass, $datatype_id, $general_search_params, $related_datatypes, $metadata, $more_debug);
                         }
 
-//print_r($results);
                         // Save the results
-                        $basic_results = array_merge($basic_results, $results);
+                        foreach ($results as $dr_id => $grandparent_id) {
+                            if ( !isset($basic_results[$dr_id]) )
+                                $basic_results[$dr_id] = $grandparent_id;
+                        }
 
                         // Save that metadata was applied to this datatype
                         $metadata[$datatype_id]['searched'] = 1;
                     }
                 }
+            }
 
 if ($debug) {
     print '----------'."\n";
     print '$basic_results: '.print_r($basic_results, true)."\n";
-    print '----------'."\n";
+//exit();
 }
 
-                // --------------------------------------------------
-                // Now, need to turn the array into a list of datarecord ids
-                $seen_datarecords = array();
-                $datarecords = array();
-                foreach ($basic_results as $num => $data) {
-                    $dr = $data['id'];
-
-                    if ( !isset($seen_datarecords[$dr]) ) {
-                        $seen_datarecords[$dr] = 0;
-                        $datarecords[] = $dr;
-                    }
-                }
-
-                // Convert into a string of datarecord ids
-                $str = '';
-                foreach ($datarecords as $num => $dr_id)
-                    $str .= $dr_id.',';
-                $datarecord_str = substr($str, 0, strlen($str)-1);
-
-                // Sort the subset of datarecords, if possible
-                $basic_search_datarecords = $odrcc->getSortedDatarecords($datatype, $datarecord_str);
-            }
-
+if ($timing)
+    print 'general search results found in: '.((microtime(true) - $start_time)*1000)."ms \n";
 
             // --------------------------------------------------
             // Want the next block to run always, because it has to catch instances where metadata for a datatype is specified, but there are no searches performed on datafields of that datatype...
@@ -1418,14 +1577,14 @@ if ($debug)
                         // Every other FieldType...
 
                         // Assume user wants exact search...
-                        $search_params = self::parseField($search_string, $debug);
+                        $search_params = self::parseField($search_string, $more_debug);
 //print_r($search_params);
                     }
 
                     // Run the query and save the results
                     $datafields = array( $datafield_id );
                     $typeclass = $datafield_array['by_id'][$datafield_id];
-                    $results = self::runSearchQuery($em, $datafields, $typeclass, $datatype_id, $search_params, $related_datatypes, $metadata);
+                    $results = self::runSearchQuery($em, $datafields, $typeclass, $datatype_id, $search_params, $related_datatypes, $metadata, $more_debug);
 
                     $using_adv_search = true;
                     $adv_results[$datafield_id] = $results;
@@ -1434,8 +1593,8 @@ if ($debug)
                     $metadata[$datatype_id]['searched'] = 1;
                 }
 
-if ($debug)
-    print 'after normal searches: '.print_r($metadata, true)."\n";
+if ($more_debug)
+    print 'after general/advanced searches: '.print_r($metadata, true)."\n";
 
                 // --------------------------------------------------
                 // Check to see if any pieces of metadata didn't get searched on
@@ -1469,14 +1628,14 @@ if ($debug)
                         $metadata_str = $search_metadata['metadata_str'].' GROUP BY grandparent.id';
                         $parameters = $search_metadata['metadata_params'];
 
-                        $query = '
-                            SELECT grandparent.id
+                        $query =
+                           'SELECT dr.id AS dr_id, grandparent.id AS grandparent_id
                             FROM odr_data_record AS grandparent
                             INNER JOIN odr_data_record AS dr ON grandparent.id = dr.grandparent_id
                             '.$linked_join.'
                             '.$where.' AND dr.deletedAt IS NULL AND grandparent.deletedAt IS NULL '.$metadata_str;
 
-if ($debug) {
+if ($more_debug) {
     print $query."\n";
     print '$parameters: '.print_r($parameters, true)."\n";
 }
@@ -1486,122 +1645,157 @@ if ($debug) {
                         $conn = $em->getConnection();
                         $results = $conn->fetchAll($query, $parameters);
 
-if ($debug) {
+if ($more_debug) {
     print '>> '.print_r($results, true)."\n";
 }
 
                         // Save the query result so the search results are correctly restricted
                         $using_adv_search = true;
-                        $adv_results['dt_'.$datatype_id.'_metadata'] = $results;
+                        foreach ($results as $result) {
+                            $dr_id = $result['dr_id'];
+                            $grandparent_id = $result['grandparent_id'];
+
+                            if ( !isset($adv_results['dt_'.$datatype_id.'_metadata']) )
+                                $adv_results['dt_'.$datatype_id.'_metadata'] = array();
+                            $adv_results['dt_'.$datatype_id.'_metadata'][$dr_id] = $grandparent_id;
+                        }
                     }
                 }
+            }
+
 if ($debug) {
     print '----------'."\n";
     print '$adv_results: '.print_r($adv_results, true)."\n";
-    print '----------'."\n";
+//exit();
 }
 
+if ($timing)
+    print 'adv search/metadata results gathered in: '.((microtime(true) - $start_time)*1000)."ms \n";
 
-                // --------------------------------------------------
-                // Now, need to turn the metadata/datafield array into a list of datarecord ids
-                $has_result = false;
-                $datarecords = array();
-                foreach ($adv_results as $datafield_id => $tmp) {
-                    if ($tmp !== 'any') {
-                        $has_result = true;
-                        // Due to this search being an implicit AND, if one of the datafields had no hits on the search term, everything fails
-                        if ( count($tmp) == 0 ) {
-                            $datarecords = array();
-                            break;
+
+            // ----------------------------------------
+            // Now, need to combine both $basic_results and $adv_results into a list of datarecord ids that matched the search...
+
+            // $adv_results stores all results for all datafields on the same level for simplicity...but intersections need to be performed only within a datatype
+            foreach ($datafield_array['by_datatype'] as $dt_id => $tmp) {
+                // Use $intersection to temporarily hold...
+                $intersection = array();
+
+                // Check for each possible piece of data that could have been searched on
+                foreach ($tmp as $num => $df_id) {
+                    // Don't bother if the datafield/metadata wasn't searched on
+                    if ( !isset($adv_results[$df_id]) )
+                        continue;
+
+                    // If no datarecords matched the search, do nothing
+                    if ( !is_array($intersection) || count($adv_results[$df_id]) == 0 ) {
+                        $intersection = false;
+                    }
+                    else if ( count($intersection) == 0 ) {
+                        // ...if nothing has been stored in $intersection yet, store this
+                        $intersection = $adv_results[$df_id];
+                    }
+                    else {
+                        // ...otherwise, remove datarecords from $intersection that aren't in $adv_results[$df_id]
+                        foreach ($intersection as $dr_id => $gp_id) {
+                            if ( !isset($adv_results[$df_id][$dr_id]) )
+                                unset( $intersection[$dr_id] );
                         }
-
-                        // Otherwise, flatten $data into a 2D array where $datarecords[$datafield_id] = <list of datarecords matching search term for $datafield_id>
-                        $datarecord_list = array();
-                        foreach ($tmp as $key => $data)
-                            $datarecord_list[] = $data['id'];
-                        $datarecords[] = $datarecord_list;
                     }
                 }
 
-                if ($has_result == true) {
-                    // Reduce $datarecords into a list of datarecord ids that matched all search terms
-                    if ( count($datarecords) == 1 ) {
-                        $datarecords = $datarecords[0];
-                    }
-                    else if ( count($datarecords) > 1 ) {
-                        $tmp = $datarecords[0];
-                        for ($i = 1; $i < count($datarecords); $i++)
-                            $tmp = array_intersect($tmp, $datarecords[$i]);
-                        $datarecords = $tmp;
-                    }
-
-                    // Convert into a string of datarecord ids
-                    $str = '';
-                    foreach ($datarecords as $num => $dr_id)
-                        $str .= $dr_id.',';
-                    $datarecord_str = substr($str, 0, strlen($str)-1);
-
-                    // Sort the subset of datarecords, if possible
-                    $adv_search_datarecords = $odrcc->getSortedDatarecords($datatype, $datarecord_str);
-                }
-                else {
-                    // Metadata and datafield searches produced no results...datarecord list restriction will depend solely on general search
-                    $adv_search_datarecords = 'any';
+                // If there was a general search string, remove datarecords from $intersection that aren't in $basic_results
+                if ($general_string !== null) {
+                    foreach ($intersection as $dr_id => $gp_id)
+                        if ( !isset($basic_results[$dr_id]) )
+                            unset( $intersection[$dr_id] );
                 }
 
+                // ...now that $intersection has the correct set of datarecords of this datatype that matched the search, update $matched_datarecords with the results
+                if ( is_array($intersection) && count($intersection) > 0 ) {
+if ($debug)
+    print '$intersection of dt '.$dt_id.': '.print_r($intersection, true)."\n";
+
+                    // Mark each of the datarecords left after the intersections as matching the search
+                    foreach ($intersection as $dr_id => $gp_id)
+                        $matched_datarecords[$dr_id] = 1;
+                }
+            }
+
+if ($timing)
+    print 'search results intersection calculated in: '.((microtime(true) - $start_time)*1000)."ms \n";
+
+            // Deal with the case where there's only a general search string
+            if ( $general_string !== null && count($basic_results) > 0 && count($adv_results) == 0 ) {
+                foreach ($basic_results as $dr_id => $gp_id) {
+                    // All datarecords in $basic_results match the general search string by definition
+                    $matched_datarecords[$dr_id] = 1;
+
+                    // All of their grandparents are also considered to match by definition
+                    $matched_datarecords[$gp_id] = 1;
+                }
+            }
+
+
+            // ----------------------------------------
+            // Compute the final list of datarecords/grandparent datarecords...
+            $datarecords = '';
+            $grandparents = '';
+
+            if ( $general_string === null && count($searched_datafields) == 0 && count($metadata) == 0 ) {
+                // In the case when there was nothing entered in the search at all...every possible datarecord satisfies the search
+                foreach ($matched_datarecords as $dr_id => $flag)
+                    $datarecords .= $dr_id.',';
+                $datarecords = substr($datarecords, 0, -1);
+
+                $grandparents = $odrcc->getSortedDatarecords($datatype);
+            }
+            else {
+                // In the case where something was searched on...
+
+if ($more_debug) {
+    print '$matched_datarecords: '.print_r($matched_datarecords, true)."\n";
+    print '$descendants_of_datarecord: '.print_r($descendants_of_datarecord, true)."\n";
+}
+
+                // Build the final list of datarecords/grandparent datarecords matched by the query
+                foreach ($descendants_of_datarecord[0] as $dt_id => $top_level_datarecords) {
+                    foreach ($top_level_datarecords as $gp_id => $tmp) {
+                        $results = self::getFinalSearchResults($matched_datarecords, $descendants_of_datarecord[0][$dt_id], $gp_id);
+
+                        $datarecords .= $results;
+                        if ($results !== '')
+                            $grandparents .= $gp_id.',';
+                    }
+                }
+
+                // Remove trailing commas
+                if (strpos($datarecords, ',') !== false)
+                    $datarecords = substr($datarecords, 0, -1);
+                if (strpos($grandparents, ',') !== false) {
+                    $grandparents = substr($grandparents, 0, -1);
+                    $grandparents = $odrcc->getSortedDatarecords($datatype, $grandparents);
+                }
             }
 
 if ($debug) {
     print '----------'."\n";
-    print '$basic_search_datarecords: '.print_r($basic_search_datarecords, true)."\n";
-    print '$adv_search_datarecords: '.print_r($adv_search_datarecords, true)."\n";
     print '----------'."\n";
+    print '$datarecords: '.$datarecords."\n";
+    print '$grandparents: '.$grandparents."\n";
+
+    if ($grandparents == '')
+        print 'count($grandparents): 0'."\n";
+    else
+        print 'count($grandparents): '.(substr_count($grandparents,',')+1)."\n";
+
+    print '----------'."\n";
+//    exit();
 }
 
+if ($timing)
+    print 'final datarecord lists calculated in: '.((microtime(true) - $start_time)*1000)."ms \n";
 
-            // --------------------------------------------------
-            // Combine advanced and basic search results if necessary
-            $datarecords = '';
-            if ($using_adv_search && trim($general_string) !== '') {
-if ($debug)
-    print "a\n";
-                if ($adv_search_datarecords == 'any') {
-                    $datarecords = $basic_search_datarecords;
-                }
-                else {
-                    // Some combination of both basic and adv search...only return records that are in both basic and adv search
-                    $basic_search_datarecords = explode(',', $basic_search_datarecords);
-                    $adv_search_datarecords = explode(',', $adv_search_datarecords);
-
-                    $str = '';
-                    foreach ($basic_search_datarecords as $b_dr) {
-                        if ( in_array($b_dr, $adv_search_datarecords) )
-                            $str .= $b_dr.',';
-                    }
-                    $datarecords = substr($str, 0, strlen($str)-1);
-                }
-            }
-            else if (trim($general_string) !== '') {
-if ($debug)
-    print "b\n";
-                // used basic search, return any results
-                $datarecords = $basic_search_datarecords;
-            }
-            else if ($using_adv_search && $adv_search_datarecords != 'any') {
-if ($debug)
-    print "c\n";
-                // used adv search, return any results
-                $datarecords = $adv_search_datarecords;
-            }
-            else {
-if ($debug)
-    print "d\n";
-                // Nothing entered in either search, return everything
-                $datarecords = $odrcc->getSortedDatarecords($datatype);
-            }
-
-if ($debug)
-    print '$datarecords: '.$datarecords."\n";
 
             // --------------------------------------------------
             // Store the list of datarecord ids for later use
@@ -1611,11 +1805,15 @@ if ($debug)
 
             $search_checksum = md5($search_key);
             $datatype_id = $datatype->getId();
+            $searched_datafields = implode(',', $searched_datafields);
 
             $cached_searches = $memcached->get($memcached_prefix.'.cached_search_results');
 
-if ($debug) {
-    print '$cached_searches: '.print_r($cached_searches, true)."\n";
+if ($debug || $more_debug || $timing)
+    print '</pre>';
+
+if ($timing) {
+    print 'total execution time: '.((microtime(true) - $start_time)*1000)."ms \n";
     exit();
 }
 
@@ -1632,20 +1830,125 @@ if ($debug) {
 
             // Store the data in the memcached entry
             if ($logged_in)
-                $cached_searches[$datatype_id][$search_checksum]['logged_in'] = array('datarecord_list' => $datarecords);
+                $cached_searches[$datatype_id][$search_checksum]['logged_in'] = array('complete_datarecord_list' => $datarecords, 'datarecord_list' => $grandparents);
             else
-                $cached_searches[$datatype_id][$search_checksum]['not_logged_in'] = array('datarecord_list' => $datarecords);
+                $cached_searches[$datatype_id][$search_checksum]['not_logged_in'] = array('complete_datarecord_list' => $datarecords, 'datarecord_list' => $grandparents);
 
             $memcached->set($memcached_prefix.'.cached_search_results', $cached_searches, 0);
 
-if ($debug) {
-    print 'saving datarecord_str: '.$datarecords."\n";
-
+if ($more_debug) {
+//    print 'saving datarecord_str: '.$datarecords."\n";
     print_r($cached_searches);
 }
         }
 
         return true;
+    }
+
+
+    /**
+     * Turns the originally flattened $descendants_of_datarecord array into a recursive tree structure of the form...
+     *
+     * parent_datarecord_id => array(
+     *     child_datatype_1_id => array(
+     *         child_datarecord_1_id of child_datatype_1 => '',
+     *         child_datarecord_2_id of child_datatype_1 => '',
+     *         ...
+     *     ),
+     *     child_datatype_2_id => array(
+     *         child_datarecord_1_id of child_datatype_2 => '',
+     *         child_datarecord_2_id of child_datatype_2 => '',
+     *         ...
+     *     ),
+     *     ...
+     * )
+     *
+     * If child_datarecord_X_id has children of its own, then it is also a parent datarecord, and it points to another recursive tree structure of this type instead of an empty string.
+     * Linked datatypes/datarecords are handled identically to child datatypes/datarecords.
+     *
+     * The tree's root looks like...
+     *
+     * 0 => array(
+     *     target_datatype_id => array(
+     *         top_level_datarecord_1_id => ...
+     *         top_level_datarecord_2_id => ...
+     *         ...
+     *     )
+     * )
+     *
+     * @param array $descendants_of_datarecord
+     * @param string|integer $current_datarecord_id
+     *
+     * @return array
+     */
+    private function buildDatarecordTree($descendants_of_datarecord, $current_datarecord_id)
+    {
+        if ( !isset($descendants_of_datarecord[$current_datarecord_id]) ) {
+            // $current_datarecord_id has no children
+            return '';
+        }
+        else {
+            // $current_datarecord_id has children
+            $result = array();
+
+            // For every child datatype this datarecord has...
+            foreach ($descendants_of_datarecord[$current_datarecord_id] as $dt_id => $datarecords) {
+                // For every child datarecord of this child datatype...
+                foreach ($datarecords as $dr_id => $tmp) {
+                    // ...get all children of this child datarecord and store them
+                    $result[$dt_id][$dr_id] = self::buildDatarecordTree($descendants_of_datarecord, $dr_id);
+                }
+            }
+
+            return $result;
+        }
+    }
+
+
+    /**
+     * Recursively traverses the datarecord tree for all datarecords if the datatype being searched on, and returns a comma-separated
+     *  list of all child/linked/top-level datarecords that effectively match the search query
+     *
+     * @param array $matched_datarecords
+     * @param array $descendants_of_datarecord
+     * @param string|integer $current_datarecord_id
+     *
+     * @return string
+     */
+    private function getFinalSearchResults($matched_datarecords, $descendants_of_datarecord, $current_datarecord_id)
+    {
+        // If this datarecord is excluded from the search results for some reason, don't bother checking any child datarecords...they're also excluded by definition
+        if ( $matched_datarecords[$current_datarecord_id] == -1 ) {
+            return '';
+        }
+        // If this datarecord has children...
+        else if ( is_array($descendants_of_datarecord[$current_datarecord_id]) ) {
+            // ...keep track of whether each child datarecord matched the search
+            $datarecords = '';
+
+            foreach ($descendants_of_datarecord[$current_datarecord_id] as $dt_id => $child_datarecords) {
+
+                $dr_matches = '';
+                foreach ($child_datarecords as $dr_id => $tmp)
+                    $dr_matches .= self::getFinalSearchResults($matched_datarecords, $descendants_of_datarecord[$current_datarecord_id][$dt_id], $dr_id);
+
+                if ($dr_matches == '') {
+                    // None of the child datarecords of this datatype matched the search...therefore the parent datarecord doesn't match either
+                    return '';
+                }
+                else {
+                    // Save the child datarecords that matched this search
+                    $datarecords .= $dr_matches;
+                }
+            }
+
+            // ...otherwise, return this datarecord and all of the child datarecords that matched
+            return $current_datarecord_id.','.$datarecords;
+        }
+        else {
+            // ...otherwise, this datarecord has no children, and either matches the search or is not otherwise excluded
+            return $current_datarecord_id.',';
+        }
     }
 
 
@@ -1658,14 +1961,15 @@ if ($debug) {
      * @param string $typeclass        The typeclass of every datafield in $datafield_list
      * @param array $search_params     
      * @param array $related_datatypes @see self::getRelatedDatatypes()
-     * @param array $metadata          
+     * @param array $metadata
+     * @param boolean $debug
      *
      * @return array TODO
      */
-    private function runSearchQuery($em, $datafield_list, $typeclass, $datatype_id, $search_params, $related_datatypes, $metadata)
+    private function runSearchQuery($em, $datafield_list, $typeclass, $datatype_id, $search_params, $related_datatypes, $metadata, $debug)
     {
-$debug = true;
-$debug = false;
+//$debug = true;
+//$debug = false;
 
         // Conversion array from typeclass to physical table name
         $table_names = array(
@@ -1704,7 +2008,6 @@ $debug = false;
         // Always include created/updated/public metadata for the grandparent if it exists...
         $metadata_str = '';
         $target_datatype_id = $related_datatypes['target_datatype'];
-        $from_linked_datatype = false;
         if ( isset($metadata[$target_datatype_id]) )  {
             $search_metadata = self::buildMetadataQueryStr($metadata[$target_datatype_id], 'grandparent');
 
@@ -1728,17 +2031,9 @@ $debug = false;
             }
         }
         else if ( in_array($datatype_id, $related_datatypes['linked_datatypes']) ) {
-
-            $from_linked_datatype = true;
-
-            // Searching from a linked datatype requires different INNER JOINs
-            $drf_join = 'INNER JOIN odr_linked_data_tree AS ldt ON dr.id = ldt.ancestor_id
-                INNER JOIN odr_data_record AS ldr ON ldt.descendant_id = ldr.id
-                INNER JOIN odr_data_record_fields AS drf ON drf.data_record_id = ldr.id';
-
             // Searching from a linked datatype also requires different metadata
             if ( isset($metadata[$datatype_id]) ) {
-                $search_metadata = self::buildMetadataQueryStr($metadata[$datatype_id], 'ldr');
+                $search_metadata = self::buildMetadataQueryStr($metadata[$datatype_id], 'dr');
 
                 if ( $search_metadata['metadata_str'] !== '' ) {
                     $metadata_str .= $search_metadata['metadata_str'];
@@ -1753,7 +2048,7 @@ $debug = false;
         if ($typeclass == 'Radio') {
             // Build the native SQL query specifically for Radio datafields
             $query =
-               'SELECT grandparent.id AS id
+               'SELECT dr.id AS dr_id, grandparent.id AS grandparent_id
                 FROM odr_data_record AS grandparent
                 INNER JOIN odr_data_record AS dr ON grandparent.id = dr.grandparent_id
                 '.$drf_join.'
@@ -1762,16 +2057,12 @@ $debug = false;
                 WHERE drf.data_field_id IN ('.$datafields.') AND ('.$search_params['str'].')
                 AND grandparent.deletedAt IS NULL AND dr.deletedAt IS NULL AND drf.deletedAt IS NULL AND rs.deletedAt IS NULL AND ro.deletedAt IS NULL ';
 
-            if ($from_linked_datatype)
-                $query .= 'AND ldt.deletedAt IS NULL AND ldr.deletedAt IS NULL AND dr.data_type_id = '.$target_datatype_id.' '; // TODO - links to childtypes?
-
             $query .= $metadata_str;
-            $query .= ' GROUP BY grandparent.id';
         }
         else if ($typeclass == 'Image' || $typeclass == 'File') {
             // Build the native SQL query that will check for (non)existence of files/images in this datafield
             $query =
-               'SELECT grandparent.id AS id
+               'SELECT dr.id AS dr_id, grandparent.id AS grandparent_id
                 FROM odr_data_record AS grandparent
                 INNER JOIN odr_data_record AS dr ON grandparent.id = dr.grandparent_id
                 '.$drf_join.'
@@ -1779,16 +2070,12 @@ $debug = false;
                 WHERE drf.data_field_id IN ('.$datafields.') AND ('.$search_params['str'].')
                 AND grandparent.deletedAt IS NULL AND dr.deletedAt IS NULL AND drf.deletedAt IS NULL AND e.deletedAt IS NULL ';
 
-            if ($from_linked_datatype)
-                $query .= 'AND ldt.deletedAt IS NULL AND dr.data_type_id = '.$target_datatype_id.' ';   // TODO - links to childtypes?
-
             $query .= $metadata_str;
-            $query .= ' GROUP BY grandparent.id';
         }
         else {
             // Build the native SQL query that will check content of any other datafields
             $query =
-               'SELECT grandparent.id AS id
+               'SELECT dr.id AS dr_id, grandparent.id AS grandparent_id
                 FROM odr_data_record AS grandparent
                 INNER JOIN odr_data_record AS dr ON grandparent.id = dr.grandparent_id
                 '.$drf_join.'
@@ -1796,11 +2083,7 @@ $debug = false;
                 WHERE '.$datafield_str.' AND ('.$search_params['str'].')
                 AND dr.deletedAt IS NULL AND grandparent.deletedAt IS NULL AND drf.deletedAt IS NULL AND e.deletedAt IS NULL ';
 
-            if ($from_linked_datatype)
-                $query .= 'AND ldt.deletedAt IS NULL AND ldr.deletedAt IS NULL AND dr.data_type_id = '.$target_datatype_id.' '; // TODO - links to childtypes?
-
             $query .= $metadata_str;
-            $query .= ' GROUP BY grandparent.id';
         }
 
 if ($debug) {
@@ -1817,7 +2100,11 @@ if ($debug) {
     print '>> '.print_r($results, true)."\n";
 }
 
-        return $results;
+        $datarecords = array();
+        foreach ($results as $result)
+            $datarecords[ $result['dr_id'] ] = $result['grandparent_id'];
+
+        return $datarecords;
     }
 
 

--- a/src/ODR/OpenRepository/SearchBundle/Resources/views/Default/index_error.html.twig
+++ b/src/ODR/OpenRepository/SearchBundle/Resources/views/Default/index_error.html.twig
@@ -1,0 +1,83 @@
+{% extends '::base.html.twig' %}
+
+{# set variables used by the parent template...http://stackoverflow.com/questions/17244162/symfony2-twig-how-can-i-send-parameters-to-the-parent-template #}
+
+{% set current_user = '' %}
+{% if user != null %}
+    {% set current_user = user.getuserstring %}
+{% endif %}
+
+{% if logged_in == false %}
+    {% set header_left_title = 'Search' %}
+    {% set header_left_path = path('odr_search', {'search_slug': search_slug} ) %}
+
+    {% set header_middle_title = '' %}
+    {% set header_middle_path = '' %}
+
+    {% set header_right_title = 'Login' %}
+    {% set header_right_path = '' %}
+    {% set header_right_js = 'ODRLogin();' %}
+{% else %}
+    {% set header_left_title = 'Dashboard' %}
+    {% set header_left_path = path('odr_admin_homepage') %}
+
+    {% set header_middle_title = 'Search' %}
+    {% set header_middle_path = path('odr_search', {'search_slug': search_slug} ) %}
+
+    {% set header_right_title = 'Logout' %}
+    {% set header_right_path = path('odr_logout') %}
+    {% set header_right_js = '' %}
+{% endif %}
+
+
+{% block title %}{{ window_title }}{% endblock %}
+
+{% set use_navigation_block = false %}
+{% if user != null %}
+    {% set use_navigation_block = true %}
+{% endif %}
+
+{% block navigation_top %}
+{% include 'ODRAdminBundle::navigation.html.twig' with {'user': user, 'user_permissions': user_permissions} %}
+{% endblock %}
+
+
+{% block body %}
+
+    {% include 'ODROpenRepositorySearchBundle:Default:searchpage_error.html.twig' with {'error_message': error_message} %}
+
+    {% set logged_in = false %} {# prevent dashboard from loading automatically #}
+    {% import "ODRAdminBundle:Default:common_js.html.twig" as js %}
+    {{ js.write(logged_in) }}
+
+    <script>
+        function ODRLogin() {
+            $(function() {
+                var url = window.location.href;
+                if ( url.indexOf('{{ site_baseurl }}/{{ search_slug }}') !== -1 ) {
+                    {#url = url.replace('{{ site_baseurl }}/{{ search_slug }}', '{{ site_baseurl }}/login');#}
+
+                    var new_url = '{{ site_baseurl }}/login';
+
+                    if ( url.indexOf('#') !== -1 ) {
+                        var pieces = url.split('#');
+                        new_url += '#' + pieces[1];
+                    }
+
+                    url = new_url;
+                }
+                else if ( url.indexOf('#') !== -1 ) {
+                    var pieces = url.split('#');
+                    url = pieces[0] + 'login#' + pieces[1];
+                }
+                else {
+                    url = "{{ path('odr_admin_homepage') }}";
+                }
+
+//alert(url);
+                window.location.href = url;
+            });
+        }
+    </script>
+{% endblock %}
+

--- a/src/ODR/OpenRepository/SearchBundle/Resources/views/Default/search.html.twig
+++ b/src/ODR/OpenRepository/SearchBundle/Resources/views/Default/search.html.twig
@@ -58,17 +58,19 @@
 
         {# render children of target datatype next #}
         {% for child_datatype_id, datafield_list in related_datatypes['child_datatypes'] %}
-            {% if target_datatype.id != child_datatype_id and searchable_datafields[child_datatype_id] is defined %}
+            {% if target_datatype.id != child_datatype_id and (searchable_datafields[child_datatype_id] is defined or logged_in == true) %}
             <fieldset>
                 <div class="ODRAdvSearch_header {#pure-u-1#}">
-                    <span>{{ searchable_datafields[ child_datatype_id ][0].getdatatype.getshortname }}</span>
+                    <span>{{ related_datatypes['datatype_names'][ child_datatype_id ] }}</span>
                     <span class="ODRAdvSearch_caret"><i class="fa fa-lg fa-caret-up"></i></span>
                 </div>
                 {#<div class="pure-u-1-24"></div>#}
                 <div class="ODRAdvSearch_content {#pure-u-23-24#} pure-u-1">
-                {% for datafield in searchable_datafields[ child_datatype_id ] %}
-                    {% include 'ODROpenRepositorySearchBundle:Default:search_datafield.html.twig' with { 'datafield': datafield } %}
-                {% endfor %}
+                {% if searchable_datafields[child_datatype_id] is defined %}
+                    {% for datafield in searchable_datafields[child_datatype_id] %}
+                        {% include 'ODROpenRepositorySearchBundle:Default:search_datafield.html.twig' with { 'datafield': datafield } %}
+                    {% endfor %}
+                {% endif %}
 
                 {# created/modified by, created/modified date, public status of child datarecord #}
                 {% if logged_in == true %}
@@ -84,7 +86,7 @@
             {% if searchable_datafields[linked_datatype_id] is defined %}
             <fieldset>
                 <div class="ODRAdvSearch_header {#pure-u-1#}">
-                    <span>{{ searchable_datafields[ linked_datatype_id ][0].getdatatype.getshortname }}</span>
+                    <span>{{ related_datatypes['datatype_names'][ linked_datatype_id ] }}</span>
                     <span class="ODRAdvSearch_caret"><i class="fa fa-lg fa-caret-up"></i></span>
                 </div>
                 {#<div class="pure-u-1-24"></div>#}


### PR DESCRIPTION
Important
- fixed CSV importing being unable to upload files/images as a result of changes made in 1.1.5 (likely caused by commit d948085)
- fixed myriad UI issues related to cancelling a file upload/download
- changing a file/image to public now creates a decryption progressbar so the server doesn't appear to be doing nothing...really only an issue with large files/images
- graph plugin no longer always displays non-public datarecords to every user
- MassEdit able to update public status of files/images and child datarecords now
- attempting to access a search page for a missing/deleted/non-public datatype now displays an actual html page instead of an ugly JSON message.  Oops.
- searching correctly handles child/linked datarecords now...previously it had a tendency to return more datarecords than it should have

Not as Important
- search page always allows searches of created/modified/public status of datarecords, even if the datatype don't have searchable datafields
- tweaked messages displayed when searches return no datarecords
- deleting a datatype redirects to the datatype list instead of just reloading the page now
- double-quotes in datafield names now properly escaped...won't crash Datatables plugin
- Able to rotate any uploaded image 90 degrees (counter)clockwise from the edit page